### PR TITLE
[#6] Make local dev stack runnable end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,26 @@
 # ===========================================
 # AeroFly Environment Configuration
 # ===========================================
-# Copy this file to .env and fill in the values
+# Copy this file to .env and adjust values.
+# .env is gitignored — never commit it.
 
-# --- PostgreSQL ---
+# --- PostgreSQL (INSIDE the docker network) ---
 POSTGRES_USER=aerofly
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=aerofly
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
+
+# --- Host-side port mappings (avoid collisions with local services) ---
+# Change these if you already run something on the default ports.
+POSTGRES_PORT_HOST=15432
+REDIS_PORT_HOST=16379
+MEILI_PORT_HOST=17700
+GATEWAY_PORT_HOST=18000
+DATA_INGESTION_PORT_HOST=18001
+SEARCH_PORT_HOST=18002
+FRONTEND_PORT_HOST=13000
+NGINX_PORT_HOST=8080
 
 # --- Redis ---
 REDIS_HOST=redis
@@ -35,4 +47,6 @@ SEARCH_PORT=8002
 
 # --- Frontend ---
 FRONTEND_PORT=3000
-VITE_API_BASE_URL=http://localhost:8000/api
+VITE_API_BASE_URL=http://localhost:8080/api
+# Or point directly at the gateway on its host port:
+# VITE_API_BASE_URL=http://localhost:18000/api

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,17 @@ logs/
 
 # Alembic
 alembic/versions/__pycache__/
+
+# Playwright / browser automation artefacts
+.playwright/
+playwright-report/
+test-results/
+*.har
+
+# DFS scraper working data (raw PDFs / HTML dumps)
+data/
+scripts/dfs_*.html
+scripts/dfs_*.png
+
+# Keep .env.example tracked even though .env is ignored
+!.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # --- Infrastructure ---
   postgres:
@@ -9,20 +7,20 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: ${POSTGRES_DB:-aerofly}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT_HOST:-15432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infrastructure/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aerofly"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-aerofly}"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT_HOST:-16379}:6379"
     volumes:
       - redis_data:/data
       - ./infrastructure/redis/redis.conf:/usr/local/etc/redis/redis.conf
@@ -31,7 +29,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   meilisearch:
     image: getmeili/meilisearch:v1.12
@@ -39,14 +37,15 @@ services:
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:-changeme_meili_key}
       MEILI_ENV: development
     ports:
-      - "7700:7700"
+      - "${MEILI_PORT_HOST:-17700}:7700"
     volumes:
       - meili_data:/meili_data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:7700/health | grep -q available"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
 
   # --- Application Services ---
   gateway:
@@ -54,7 +53,7 @@ services:
       context: ./services/gateway
       dockerfile: Dockerfile
     ports:
-      - "${GATEWAY_PORT:-8000}:8000"
+      - "${GATEWAY_PORT_HOST:-18000}:8000"
     env_file: .env
     volumes:
       - ./services/gateway:/app
@@ -64,45 +63,66 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health').read()"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
 
   data-ingestion:
     build:
       context: ./services/data-ingestion
       dockerfile: Dockerfile
     ports:
-      - "${DATA_INGESTION_PORT:-8001}:8001"
+      - "${DATA_INGESTION_PORT_HOST:-18001}:8001"
     env_file: .env
     volumes:
       - ./services/data-ingestion:/app
       - ./shared/python:/app/shared
+      - ./scripts:/app/scripts:ro
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health').read()"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
 
   search:
     build:
       context: ./services/search
       dockerfile: Dockerfile
     ports:
-      - "${SEARCH_PORT:-8002}:8002"
+      - "${SEARCH_PORT_HOST:-18002}:8002"
     env_file: .env
     volumes:
       - ./services/search:/app
       - ./shared/python:/app/shared
     depends_on:
+      postgres:
+        condition: service_healthy
       meilisearch:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8002/health').read()"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
 
   frontend:
     build:
       context: ./services/frontend
       dockerfile: Dockerfile
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      - "${FRONTEND_PORT_HOST:-13000}:3000"
     volumes:
       - ./services/frontend:/app
       - /app/node_modules
@@ -113,7 +133,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:80"
+      - "${NGINX_PORT_HOST:-8080}:80"
     volumes:
       - ./infrastructure/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -39,3 +39,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — Make the stack runnable end-to-end (`develop`)
 
 > build docker and perform all end-to-end testing and do everything so that I can run it.
+
+### 2026-04-19 — Run housekeeping after making stack runnable (`chore/6-runnable-dev-env`)
+
+> do housekeeping

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -35,3 +35,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — Run housekeeping after schema work (`feat/4-db-schema-foundation`)
 
 > do housekeeping
+
+### 2026-04-19 — Make the stack runnable end-to-end (`develop`)
+
+> build docker and perform all end-to-end testing and do everything so that I can run it.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,145 @@
+# AeroFly — Local Runbook
+
+How to run the stack locally in under five minutes.
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine + compose v2)
+- `bash` shell (WSL / Git Bash on Windows)
+- ~2 GB free RAM
+
+## First-time setup
+
+```bash
+# 1. Create local env file (gitignored).
+cp .env.example .env
+
+# 2. (Optional) Edit .env to adjust host-side ports if your machine already
+#    runs Postgres/Redis/Meilisearch. Defaults avoid the common ports:
+#      POSTGRES_PORT_HOST=55432
+#      REDIS_PORT_HOST=56379
+#      MEILI_PORT_HOST=57700
+#      NGINX_PORT_HOST=8080
+```
+
+## Start the stack
+
+```bash
+docker compose up --build -d
+```
+
+Wait ~30 s for all services to become healthy:
+
+```bash
+docker compose ps
+```
+
+You should see `(healthy)` next to `postgres`, `redis`, `meilisearch`,
+`gateway`, `data-ingestion`, and `search`. `frontend` and `nginx` do not
+ship a healthcheck yet; they are either `running` or `exited`.
+
+## Apply database migrations
+
+```bash
+bash scripts/migrate-all.sh
+```
+
+This runs `alembic upgrade head` inside each migration-owning container
+(`data-ingestion`, `search`, `gateway`) and creates:
+
+- `ingest.*` — 6 tables + 9 enums (authoritative domain data)
+- `search.*` — empty (projections land when Meilisearch sync track starts)
+- `gateway.*` — empty (API tables land when Gateway API track starts)
+
+## Verify
+
+| URL | What you should see |
+|---|---|
+| `http://localhost:8080/` | Frontend "Hello AeroFly" page (via nginx) |
+| `http://localhost:8080/api/health` | `{"status":"ok","service":"gateway"}` |
+| `http://localhost:8080/api/docs` | Swagger UI for the gateway |
+| `http://localhost:18000/api/health` | Gateway directly |
+| `http://localhost:18001/health` | Data-ingestion directly |
+| `http://localhost:18001/docs` | Data-ingestion Swagger |
+| `http://localhost:18002/health` | Search directly |
+| `http://localhost:13000/` | Frontend Vite dev server directly |
+| `http://localhost:17700/health` | Meilisearch |
+
+## Smoke-test the database round-trip
+
+With the stack running and migrations applied:
+
+```bash
+docker compose exec data-ingestion python scripts/smoke_test_db.py
+```
+
+Expected output (all OK lines):
+
+```
+OK  aerodrome          : ZZZZ / Smoketest Airport / Smoketest Flughafen
+OK  runways            : 1
+OK  frequencies        : 3
+OK  charts             : 1
+OK  notams             : 1
+OK  airac cycle        : 2026-04
+OK  rollback           : clean — no data persisted
+```
+
+## Shutdown
+
+```bash
+# Stop containers (keep volumes — next startup reuses DB)
+docker compose stop
+
+# Stop and remove containers (keep volumes)
+docker compose down
+
+# Stop, remove containers AND wipe volumes (clean slate)
+docker compose down -v
+```
+
+## Troubleshooting
+
+### `bind: address already in use`
+Something on the host already listens on one of the default host ports.
+Override it in `.env`:
+
+```
+POSTGRES_PORT_HOST=56789
+REDIS_PORT_HOST=56780
+MEILI_PORT_HOST=57701
+NGINX_PORT_HOST=8081
+```
+
+### `env file .env not found`
+You skipped the first-time setup. Run `cp .env.example .env`.
+
+### Gateway / data-ingestion / search stuck in `starting`
+Check logs: `docker compose logs -f <service>`. The most common cause is
+that migrations haven't run yet and the healthcheck is timing out — but
+the `/health` endpoint doesn't touch the DB, so this is unusual. If it
+persists, restart: `docker compose restart <service>`.
+
+### `schema "ingest" does not exist` when running smoke test
+Run `bash scripts/migrate-all.sh` first.
+
+### Fresh rebuild after a Dockerfile / requirements change
+```bash
+docker compose up --build -d --force-recreate
+```
+
+## Ports reference (defaults)
+
+| Service | Inside container | Host default | Override var |
+|---|---|---|---|
+| postgres | 5432 | 15432 | `POSTGRES_PORT_HOST` |
+| redis | 6379 | 16379 | `REDIS_PORT_HOST` |
+| meilisearch | 7700 | 17700 | `MEILI_PORT_HOST` |
+| gateway | 8000 | 18000 | `GATEWAY_PORT_HOST` |
+| data-ingestion | 8001 | 18001 | `DATA_INGESTION_PORT_HOST` |
+| search | 8002 | 18002 | `SEARCH_PORT_HOST` |
+| frontend | 3000 | 13000 | `FRONTEND_PORT_HOST` |
+| nginx | 80 | 8080 | `NGINX_PORT_HOST` |
+
+Defaults are offset into high ranges because the common `8000/8001/8002/3000`
+ports are frequently in use by other local projects.

--- a/infrastructure/postgres/init.sql
+++ b/infrastructure/postgres/init.sql
@@ -1,11 +1,9 @@
 -- AeroFly PostgreSQL initialization
--- Creates schemas for each service module
+--
+-- NOTE: Service schemas (`ingest`, `search`, `gateway`) are created by each
+-- service's Alembic migration, not here. Keeping this file for future
+-- extension installs only.
 
-CREATE SCHEMA IF NOT EXISTS gateway;
-CREATE SCHEMA IF NOT EXISTS data_ingestion;
-CREATE SCHEMA IF NOT EXISTS search;
-
--- Grant usage
-GRANT ALL ON SCHEMA gateway TO aerofly;
-GRANT ALL ON SCHEMA data_ingestion TO aerofly;
-GRANT ALL ON SCHEMA search TO aerofly;
+-- Example for later:
+-- CREATE EXTENSION IF NOT EXISTS pg_trgm;   -- fuzzy text search on ICAO/names
+-- CREATE EXTENSION IF NOT EXISTS postgis;   -- geographic queries (deferred)

--- a/scripts/migrate-all.sh
+++ b/scripts/migrate-all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run alembic upgrade head in every service container that owns a schema.
+#
+# Usage (from the project root, stack must be running):
+#   bash scripts/migrate-all.sh
+#
+# Exit status: non-zero if any migration fails.
+
+set -euo pipefail
+
+services=(data-ingestion search gateway)
+
+for svc in "${services[@]}"; do
+  echo ">>> alembic upgrade head [$svc]"
+  docker compose exec -T "$svc" alembic upgrade head
+done
+
+echo
+echo "All migrations applied."

--- a/scripts/smoke_test_db.py
+++ b/scripts/smoke_test_db.py
@@ -18,24 +18,31 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 
-# Make `shared.python.*` importable when running from repo root.
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_PROJECT_ROOT))
-sys.path.insert(0, str(_PROJECT_ROOT / "services" / "data-ingestion"))
+# Path setup — works both locally (from repo root) and inside the
+# data-ingestion container (cwd=/app, `shared/` mounted from shared/python).
+_HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = _HERE.parent
+_IN_CONTAINER = Path("/app/shared").exists() and not (
+    _PROJECT_ROOT / "shared" / "python"
+).exists()
 
-# Alias `shared.*` -> `shared.python.*` so the service models (which import
-# `shared.schemas.enums` as they would inside the container) work locally.
-import shared.python as _shared_pkg  # type: ignore  # noqa: E402
-import shared.python.models as _shared_models  # type: ignore  # noqa: E402
-import shared.python.models.base as _shared_models_base  # type: ignore  # noqa: E402
-import shared.python.schemas as _shared_schemas  # type: ignore  # noqa: E402
-import shared.python.schemas.enums as _shared_schemas_enums  # type: ignore  # noqa: E402
+if _IN_CONTAINER:
+    sys.path.insert(0, "/app")
+else:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+    sys.path.insert(0, str(_PROJECT_ROOT / "services" / "data-ingestion"))
+    # Make `shared.schemas.*` resolve to the repo's `shared.python.schemas.*`.
+    import shared.python as _shared_pkg  # type: ignore  # noqa: E402
+    import shared.python.models as _shared_models  # type: ignore  # noqa: E402
+    import shared.python.models.base as _shared_models_base  # type: ignore  # noqa: E402
+    import shared.python.schemas as _shared_schemas  # type: ignore  # noqa: E402
+    import shared.python.schemas.enums as _shared_schemas_enums  # type: ignore  # noqa: E402
 
-sys.modules.setdefault("shared", _shared_pkg)
-sys.modules.setdefault("shared.schemas", _shared_schemas)
-sys.modules.setdefault("shared.schemas.enums", _shared_schemas_enums)
-sys.modules.setdefault("shared.models", _shared_models)
-sys.modules.setdefault("shared.models.base", _shared_models_base)
+    sys.modules.setdefault("shared", _shared_pkg)
+    sys.modules.setdefault("shared.schemas", _shared_schemas)
+    sys.modules.setdefault("shared.schemas.enums", _shared_schemas_enums)
+    sys.modules.setdefault("shared.models", _shared_models)
+    sys.modules.setdefault("shared.models.base", _shared_models_base)
 
 from app.db import get_session_factory  # noqa: E402
 from app.db.models import (  # noqa: E402
@@ -46,7 +53,7 @@ from app.db.models import (  # noqa: E402
     Notam,
     Runway,
 )
-from shared.python.schemas.enums import (  # noqa: E402
+from shared.schemas.enums import (  # noqa: E402
     AerodromeType,
     ChartType,
     FrequencyType,

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -3,7 +3,9 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# `npm ci` would be preferred but requires package-lock.json which is not
+# generated here yet. Switch back to `npm ci` once a lockfile exists.
+RUN npm install --no-audit --no-fund
 
 COPY . .
 

--- a/services/search/requirements.txt
+++ b/services/search/requirements.txt
@@ -2,6 +2,9 @@ fastapi==0.115.6
 uvicorn[standard]==0.34.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
+sqlalchemy==2.0.36
+alembic==1.14.1
+psycopg2-binary==2.9.10
 meilisearch==0.33.0
 redis==5.2.1
 httpx==0.28.1


### PR DESCRIPTION
## Summary

Fixes every blocker preventing `docker compose up --build -d` from reaching all-healthy on a fresh checkout, and adds a runbook so a newcomer gets a working stack in under five minutes.

Closes #6.

## Changes

- **Host ports are now env-driven** with high-range defaults (15432 / 16379 / 17700 / 18000–18002 / 13000 / 8080) so they don't collide with the typical 5432/6379/7700/8000–8002/3000/80 layout many dev machines already use.
- **Meilisearch healthcheck fixed**: BusyBox wget inside the alpine image doesn't support `--spider` reliably, and `localhost` resolves IPv6-first whereas Meilisearch only binds v4. Now uses `wget -q -O- http://127.0.0.1:7700/health | grep -q available`.
- **App healthchecks added** (python urllib on `/health`) so dependent services wait for each other.
- **Frontend Dockerfile**: `npm ci` → `npm install` until a `package-lock.json` is committed.
- **Search service** gains `sqlalchemy`, `alembic`, `psycopg2-binary` so it can run its own migrations.
- **init.sql** stops creating stale `data_ingestion` schema — Alembic owns schema names (`ingest`, `search`, `gateway`).
- **`scripts/migrate-all.sh`** — one command to `alembic upgrade head` in all three migration-owning containers.
- **`scripts/smoke_test_db.py`** auto-detects in-container vs local layout and sets up imports accordingly; `scripts/` mounted into data-ingestion so the test runs from inside the container too.
- **`docs/RUNBOOK.md`** — first-time setup, startup, migrations, verification URLs, shutdown, troubleshooting, ports reference.
- **`.gitignore`** extended for DFS scraper working data + Playwright artefacts.

## Services affected

All of them — mostly compose-level. Code changes are limited to search's requirements, frontend's Dockerfile, and the smoke-test script.

## Verification performed on this branch

- `docker compose up --build -d` → 6 / 6 health-checked services report `healthy`
- `bash scripts/migrate-all.sh` → all three schemas at revision `20260419_0001`
- `smoke_test_db.py` passes both in-container and locally against the compose Postgres
- `curl http://localhost:18000/api/health` → `{"status":"ok","service":"gateway"}`
- `curl http://localhost:18001/health` → `{"status":"ok","service":"data-ingestion"}`
- `curl http://localhost:18002/health` → `{"status":"ok","service":"search"}`
- `curl http://localhost:17700/health` → `{"status":"available"}`
- `curl http://localhost:8080/` → frontend HTML via nginx (200)
- `curl http://localhost:8080/api/health` → gateway via nginx (200)
- `curl http://localhost:8080/api/docs` → Swagger UI (200)

## Test plan

- [x] Fresh `docker compose down -v && docker compose up --build -d` reaches all-healthy
- [x] `bash scripts/migrate-all.sh` succeeds on a virgin Postgres
- [x] Smoke test passes inside the container
- [x] Smoke test passes locally against host-mapped Postgres
- [x] All health endpoints return expected JSON
- [x] Nginx proxies both `/` (frontend) and `/api/*` (gateway)
- [x] Gateway Swagger reachable at `/api/docs`
- [x] `.env` remains gitignored; only `.env.example` is committed
- [ ] Independent verification by @DMPlisken after merging to develop