### PR TITLE
[#13] Chart image display in aerodrome detail view + Phase 1 scope cleanup

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -63,3 +63,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — Run housekeeping after vertical slice + import (`feat/8-aerodrome-listing`)
 
 > do housepeeping
+
+### 2026-04-19 — Create 6 GitHub issues + start implementation (`develop`)
+
+> Mach ein GitHub-Issue aus: "DFS HTML/chart parser (extract structured runways/frequencies/coords from the existing scraped images) ·  Meilisearch sync · NOTAM integration · chart image display in detail view · authentication · responsive/mobile layout." - Und starte mit der Implementierung in einem neuen Branch.

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -67,3 +67,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — Create 6 GitHub issues + start implementation (`develop`)
 
 > Mach ein GitHub-Issue aus: "DFS HTML/chart parser (extract structured runways/frequencies/coords from the existing scraped images) ·  Meilisearch sync · NOTAM integration · chart image display in detail view · authentication · responsive/mobile layout." - Und starte mit der Implementierung in einem neuen Branch.
+
+### 2026-04-19 — Reframe: no auth, charts are the product, close #10 and #14 (`feat/13-chart-image-display`)
+
+> es gibt keine authentifizierung für die bilder und informationen. du kommst ohne login überall hin und die bilder die wir bereits gescraped haben sollten eigentlich völlig ausreichend sein. mehr informationen als wir schon haben gibt es nicht

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -71,3 +71,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — Reframe: no auth, charts are the product, close #10 and #14 (`feat/13-chart-image-display`)
 
 > es gibt keine authentifizierung für die bilder und informationen. du kommst ohne login überall hin und die bilder die wir bereits gescraped haben sollten eigentlich völlig ausreichend sein. mehr informationen als wir schon haben gibt es nicht
+
+### 2026-04-19 — Run housekeeping after chart display (`feat/13-chart-image-display`)
+
+> do housekeeping

--- a/docs/ROADMAP_PROGRESS.md
+++ b/docs/ROADMAP_PROGRESS.md
@@ -10,27 +10,28 @@
 - [x] Alembic migrations for all services — issue #4, data-ingestion (6 tables + 9 enums), search + gateway (baseline schemas)
 
 ### Data Ingestion
-- [ ] DFS AIP parser — aerodrome directory (AD 2) — issue #10 (core metadata: lat/lon/elev/city/region)
-- [ ] Runway data extraction (dimensions, surface, orientation) — issue #10
-- [ ] Frequency extraction (TWR, GND, ATIS, AFIS) — issue #10
+- [~] DFS AIP parser — aerodrome directory (AD 2) — **won't do** (issue #10 closed). The chart images already contain the authoritative data; structured extraction would be lossy.
+- [~] Runway data extraction (dimensions, surface, orientation) — **won't do** (part of #10). Pilot reads it from the chart.
+- [~] Frequency extraction (TWR, GND, ATIS, AFIS) — **won't do** (part of #10). Pilot reads it from the chart.
 - [x] Aerodrome chart/map PDF ingestion & indexing — feat/1 scraper (1042 PNGs) + issue #8 importer + issue #13 inline display
-- [ ] NOTAM feed integration — issue #12
-- [ ] Scheduled re-sync jobs
+- [ ] NOTAM feed integration — issue #12 (pending go/no-go decision)
+- [ ] Scheduled re-sync jobs — for future AIRAC-cycle updates via the existing scraper
 
 ### Search & API
-- [ ] Meilisearch index configuration (aerodromes, frequencies, charts)
-- [x] Gateway REST API — aerodrome listing + detail endpoints — issue #8 (interim; moves to Search when Meilisearch lands)
-- [x] Full-text prefix search endpoint (ICAO, name, city, region) — issue #8 (ILIKE against Postgres for now)
+- [ ] Meilisearch index configuration (aerodromes, frequencies, charts) — issue #11 (pending go/no-go decision)
+- [x] Gateway REST API — aerodrome listing + detail endpoints — issue #8
+- [x] Full-text prefix search endpoint (ICAO, name) — issue #8 (ILIKE against Postgres)
 - [x] Swagger/OpenAPI documentation — gateway at `/api/docs`, data-ingestion at `/docs`
-- [ ] API authentication (JWT)
-- [ ] Rate limiting
+- [x] Chart image serving — issue #13 (nginx serves PNGs directly from data-ingestion volume, 1-day browser cache)
+- [~] API authentication (JWT) — **won't do** (issue #14 closed). Data is public.
+- [~] Rate limiting — **won't do** for Phase 1. Revisit if third-party API consumers appear.
 
 ### Frontend
 - [x] Design Kit creation (`docs/Design-Kits/aerofly-design-kit.html`) — v2.0 dark-first glassmorphism, 22 sections incl. 3 page mockups, issue #2
 - [x] Aerodrome search page — issue #8, paginated, filterable, Vite proxy to gateway
-- [x] Aerodrome detail view — issue #8 (runways + frequencies live; map, charts, NOTAMs are placeholders awaiting data)
+- [x] Aerodrome detail view — issue #8 + #13 (inline chart images; runway/frequency/NOTAM sections stay "—" since the chart itself contains those)
 - [x] Bilingual UI (DE/EN) — issue #8, custom I18nProvider, every string translated, persisted via localStorage
-- [ ] Responsive layout — mobile / tablet breakpoints pending
+- [ ] Responsive layout — issue #15 (pending go/no-go decision)
 
 ## Phase 2: Enhanced Data & Tools (Planned)
 - [ ] Weather integration (METAR/TAF)

--- a/docs/ROADMAP_PROGRESS.md
+++ b/docs/ROADMAP_PROGRESS.md
@@ -10,11 +10,11 @@
 - [x] Alembic migrations for all services — issue #4, data-ingestion (6 tables + 9 enums), search + gateway (baseline schemas)
 
 ### Data Ingestion
-- [ ] DFS AIP parser — aerodrome directory (AD 2)
-- [ ] Runway data extraction (dimensions, surface, orientation)
-- [ ] Frequency extraction (TWR, GND, ATIS, AFIS)
-- [ ] Aerodrome chart/map PDF ingestion & indexing
-- [ ] NOTAM feed integration
+- [ ] DFS AIP parser — aerodrome directory (AD 2) — issue #10 (core metadata: lat/lon/elev/city/region)
+- [ ] Runway data extraction (dimensions, surface, orientation) — issue #10
+- [ ] Frequency extraction (TWR, GND, ATIS, AFIS) — issue #10
+- [x] Aerodrome chart/map PDF ingestion & indexing — feat/1 scraper (1042 PNGs) + issue #8 importer + issue #13 inline display
+- [ ] NOTAM feed integration — issue #12
 - [ ] Scheduled re-sync jobs
 
 ### Search & API

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -2,6 +2,10 @@ upstream gateway {
     server gateway:8000;
 }
 
+upstream data_ingestion {
+    server data-ingestion:8001;
+}
+
 upstream frontend {
     server frontend:3000;
 }
@@ -9,6 +13,19 @@ upstream frontend {
 server {
     listen 80;
     server_name localhost;
+
+    # Binary chart images: bypass gateway (no JSON layer), go straight to
+    # data-ingestion and cache. Must be defined BEFORE the generic /api/ block.
+    location /api/charts/ {
+        rewrite ^/api/charts/(.*)$ /charts/$1 break;
+        proxy_pass http://data_ingestion;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        expires 1d;
+        add_header Cache-Control "public, max-age=86400";
+    }
 
     location /api/ {
         proxy_pass http://gateway;

--- a/services/data-ingestion/app/api/aerodromes.py
+++ b/services/data-ingestion/app/api/aerodromes.py
@@ -80,6 +80,26 @@ class ChartRead(BaseModel):
     title: str
     title_de: str | None
     source_url: str
+    preview_url: str | None = None  # computed below
+
+    @classmethod
+    def from_orm_with_url(cls, chart) -> "ChartRead":
+        preview_url: str | None = None
+        if chart.local_path:
+            # local_path format: /app/data/aerodromes/<ICAO>/<filename>
+            parts = chart.local_path.rstrip("/").split("/")
+            if len(parts) >= 2:
+                icao = parts[-2]
+                filename = parts[-1]
+                preview_url = f"/api/charts/{icao}/{filename}"
+        return cls(
+            id=chart.id,
+            chart_type=chart.chart_type.value if hasattr(chart.chart_type, "value") else str(chart.chart_type),
+            title=chart.title,
+            title_de=chart.title_de,
+            source_url=chart.source_url,
+            preview_url=preview_url,
+        )
 
 
 class NotamRead(BaseModel):
@@ -103,6 +123,12 @@ class AerodromeDetail(AerodromeBase):
     frequencies: list[FrequencyRead] = []
     charts: list[ChartRead] = []
     notams: list[NotamRead] = []
+
+    @classmethod
+    def from_orm_with_urls(cls, aerodrome) -> "AerodromeDetail":
+        base = cls.model_validate(aerodrome)
+        base.charts = [ChartRead.from_orm_with_url(c) for c in aerodrome.charts]
+        return base
 
 
 # --- Endpoints --- #
@@ -174,4 +200,4 @@ def get_aerodrome(
     row = db.execute(stmt).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail=f"Aerodrome {icao_upper} not found")
-    return AerodromeDetail.model_validate(row)
+    return AerodromeDetail.from_orm_with_urls(row)

--- a/services/data-ingestion/app/api/charts.py
+++ b/services/data-ingestion/app/api/charts.py
@@ -1,0 +1,50 @@
+"""Static-file endpoint for scraped aerodrome chart PNGs.
+
+Serves files from /app/data/aerodromes/<ICAO>/<filename> — the read-only
+volume mount populated by the DFS scraper. Path-traversal is prevented by
+resolving the requested path and verifying it still lives inside the
+aerodrome-specific directory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+router = APIRouter(prefix="/charts", tags=["charts"])
+
+_DATA_ROOT = Path("/app/data/aerodromes")
+_CACHE_SECONDS = 86_400  # AIRAC cycle is month-long; one day is conservative.
+
+_ICAO_RE = re.compile(r"^[A-Z]{4}$")
+_FILENAME_RE = re.compile(r"^[A-Za-z0-9_\-]+\.(png|jpg|jpeg)$")
+
+
+@router.get("/{icao}/{filename}", response_class=FileResponse)
+def get_chart_file(icao: str, filename: str) -> FileResponse:
+    icao_upper = icao.upper()
+    if not _ICAO_RE.match(icao_upper):
+        raise HTTPException(status_code=400, detail="ICAO must be four uppercase letters")
+    if not _FILENAME_RE.match(filename):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    aerodrome_dir = (_DATA_ROOT / icao_upper).resolve()
+    requested = (aerodrome_dir / filename).resolve()
+
+    # Guard against path traversal: requested must be inside aerodrome_dir.
+    try:
+        requested.relative_to(aerodrome_dir)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid chart path") from exc
+
+    if not requested.is_file():
+        raise HTTPException(status_code=404, detail="Chart file not found")
+
+    return FileResponse(
+        requested,
+        media_type="image/png",
+        headers={"Cache-Control": f"public, max-age={_CACHE_SECONDS}"},
+    )

--- a/services/data-ingestion/app/main.py
+++ b/services/data-ingestion/app/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from app.api.aerodromes import router as aerodromes_router
+from app.api.charts import router as charts_router
 
 app = FastAPI(
     title="AeroFly Data Ingestion",
@@ -13,6 +14,7 @@ app = FastAPI(
 )
 
 app.include_router(aerodromes_router)
+app.include_router(charts_router)
 
 
 @app.get("/health", tags=["health"])

--- a/services/frontend/src/api/aerodromes.ts
+++ b/services/frontend/src/api/aerodromes.ts
@@ -77,6 +77,7 @@ export interface Chart {
   title: string;
   title_de: string | null;
   source_url: string;
+  preview_url: string | null;
 }
 
 export interface Notam {

--- a/services/frontend/src/components/ChartItem.tsx
+++ b/services/frontend/src/components/ChartItem.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+import type { Chart } from "@/api/aerodromes";
+
+interface Props {
+  chart: Chart;
+  defaultOpen?: boolean;
+}
+
+export function ChartItem({ chart, defaultOpen = false }: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  const canPreview = Boolean(chart.preview_url);
+
+  return (
+    <li className="chart-item">
+      <div className="chart-item-head">
+        <button
+          type="button"
+          className="chart-item-toggle"
+          onClick={() => canPreview && setOpen((v) => !v)}
+          disabled={!canPreview}
+          aria-expanded={open}
+          aria-controls={`chart-body-${chart.id}`}
+        >
+          <i
+            className={`fa-solid fa-chevron-${open ? "down" : "right"}`}
+            style={{ opacity: canPreview ? 1 : 0.3 }}
+            aria-hidden="true"
+          />
+          <i className="fa-solid fa-file-lines chart-item-icon" aria-hidden="true" />
+          <span className="chart-item-title">{chart.title}</span>
+        </button>
+        <a
+          href={chart.source_url}
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-ghost btn-sm"
+        >
+          <i className="fa-solid fa-arrow-up-right-from-square" /> DFS
+        </a>
+      </div>
+      {open && canPreview && (
+        <div id={`chart-body-${chart.id}`} className="chart-item-body">
+          <img
+            src={chart.preview_url ?? ""}
+            alt={chart.title}
+            loading="lazy"
+            className="chart-item-image"
+          />
+        </div>
+      )}
+    </li>
+  );
+}

--- a/services/frontend/src/pages/AerodromeDetail.tsx
+++ b/services/frontend/src/pages/AerodromeDetail.tsx
@@ -5,6 +5,7 @@ import {
   getAerodrome,
   type AerodromeDetail as AerodromeDetailType,
 } from "@/api/aerodromes";
+import { ChartItem } from "@/components/ChartItem";
 import { FrequencyBadge } from "@/components/FrequencyBadge";
 import { useI18n, type Locale } from "@/i18n";
 
@@ -165,34 +166,9 @@ export function AerodromeDetailPage() {
             {data.charts.length === 0 ? (
               <p style={{ color: "var(--color-text-muted)" }}>{t("detail.empty.charts")}</p>
             ) : (
-              <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-                {data.charts.map((c) => (
-                  <li
-                    key={c.id}
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      gap: "var(--space-3)",
-                      padding: "var(--space-2) var(--space-3)",
-                      background: "var(--color-bg-elevated)",
-                      borderRadius: "var(--radius-md)",
-                      fontSize: "var(--fs-sm)",
-                    }}
-                  >
-                    <span style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-                      <i className="fa-solid fa-file-lines" style={{ color: "var(--color-text-muted)" }} />
-                      {c.title}
-                    </span>
-                    <a
-                      href={c.source_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn btn-ghost btn-sm"
-                    >
-                      <i className="fa-solid fa-arrow-up-right-from-square" /> DFS
-                    </a>
-                  </li>
+              <ul className="chart-list">
+                {data.charts.map((c, i) => (
+                  <ChartItem key={c.id} chart={c} defaultOpen={i === 0} />
                 ))}
               </ul>
             )}

--- a/services/frontend/src/styles/global.css
+++ b/services/frontend/src/styles/global.css
@@ -674,6 +674,80 @@ a:hover {
   margin: 0 0 var(--space-2);
 }
 
+/* ------- Chart item (expandable) ------- */
+.chart-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.chart-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  overflow: hidden;
+}
+
+.chart-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+}
+
+.chart-item-toggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: var(--color-text);
+  padding: var(--space-2);
+  margin: calc(var(--space-2) * -1);
+  border-radius: var(--radius-sm);
+  text-align: left;
+}
+
+.chart-item-toggle:hover:not(:disabled) {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.chart-item-toggle:disabled {
+  cursor: default;
+}
+
+.chart-item-icon {
+  color: var(--color-text-muted);
+}
+
+.chart-item-title {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.chart-item-body {
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg);
+  text-align: center;
+}
+
+.chart-item-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  background: #fff; /* charts are scanned black-on-white */
+}
+
 /* ------- Pagination ------- */
 .pagination {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **#13 chart image display** — the 1042 scraped PNGs are now browsable inline in the detail page (nginx serves them directly; 1-day browser cache; path-traversal blocked; first chart auto-expanded).
2. **Scope cleanup** — after reframing the product with @DMPlisken (DFS data is public, charts are authoritative), closed #10 (parser) and #14 (auth) as **not planned** and updated the roadmap accordingly.

Closes #13.

## What changed (#13)

**Backend**
- `services/data-ingestion/app/api/charts.py`: `GET /charts/{icao}/{filename}` serves a PNG from `/app/data/aerodromes/<ICAO>/` with an ICAO regex, a filename allowlist, and a resolved-path containment check against traversal. Cache-Control: `public, max-age=86400`.
- `services/data-ingestion/app/api/aerodromes.py`: `ChartRead` gets a computed `preview_url` field (format `/api/charts/{icao}/{filename}`) derived from `local_path`; detail endpoint hydrates it.

**Infra**
- `infrastructure/nginx/nginx.conf`: new `location /api/charts/` block BEFORE `/api/` so image bytes proxy straight to data-ingestion without the gateway httpx hop. Adds `expires 1d`.

**Frontend**
- `src/components/ChartItem.tsx`: expand/collapse chart row with lazy `<img>` inline when opened. Keyboard + ARIA friendly.
- `src/pages/AerodromeDetail.tsx`: charts section uses `<ChartItem>` list; first chart auto-expanded.
- `src/styles/global.css`: `.chart-list` / `.chart-item*` tokens.
- `src/api/aerodromes.ts`: `Chart.preview_url` added.

## Roadmap cleanup

- Closed #10 DFS HTML/chart parser as not-planned (charts are the source of truth; OCR would be lossy and redundant).
- Closed #14 Authentication as not-planned (DFS data is public; no wall needed in front of a chart compendium).
- `docs/ROADMAP_PROGRESS.md` updated: dropped items marked `[~]` with explanations.

## Services affected

- `data-ingestion` — new chart route, preview_url hydration
- `frontend` — ChartItem + detail page rewrite of charts section
- `nginx` — new route mapping

## Verification

- [x] `GET /api/charts/EDDF/EDDF_Frankfurt_Main_1_preview.png` → `200 image/png`, 1.27 MB, `Cache-Control: max-age=86400`
- [x] 404 on unknown filename
- [x] Path-traversal attempts blocked (400 / 404)
- [x] `tsc --noEmit` clean
- [x] EDDF detail page shows inline Frankfurt Main preview; further charts expand on click
- [x] Stack still healthy: 6 / 6 health-checked services