### PR TITLE
[chore] SVG favicon + theme-color meta

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -95,3 +95,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-19 — GO — implement chart thumbnail grid per plan (`develop`)
 
 > go
+
+### 2026-04-19 — Add favicon for browser tabs (`develop`)
+
+> Gebe der App ein schönes Favikon Vor allem für die Browser-Tabs.

--- a/services/frontend/index.html
+++ b/services/frontend/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AeroFly — Aerodrome Compendium</title>
 
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <meta name="theme-color" content="#3b82f6" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#1a56db" media="(prefers-color-scheme: light)" />
+    <meta name="description" content="AeroFly — Aerodrome Compendium für deutsche Flughäfen. Karten, Frequenzen und Informationen aus DFS AIP." />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/services/frontend/public/favicon.svg
+++ b/services/frontend/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="AeroFly">
+  <rect width="32" height="32" rx="7" fill="#3b82f6"/>
+  <path
+    d="M16 5 L17.4 7.2 L17.4 13 L26 17.2 L26 18.8 L17.4 17 L17.4 23 L19.6 24.8 L19.6 26 L16 25 L12.4 26 L12.4 24.8 L14.6 23 L14.6 17 L6 18.8 L6 17.2 L14.6 13 L14.6 7.2 Z"
+    fill="#ffffff"
+    stroke="#ffffff"
+    stroke-width="0.4"
+    stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds a proper favicon that matches the sidebar brand mark so browser tabs and mobile home-screens actually say "AeroFly" instead of a blank globe.

## Changes

- `services/frontend/public/favicon.svg` — 32×32 viewBox, rounded-square (rx=7) in `#3b82f6` (primary blue) with a white plane-up silhouette. SVG scales crisply from 16 px tab icon to 180 px iOS home-screen.
- `services/frontend/index.html`
  - `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`
  - `<link rel="apple-touch-icon" href="/favicon.svg">`
  - `<meta name="theme-color">` in two `prefers-color-scheme` variants (`#3b82f6` dark, `#1a56db` light) — matches our Design Kit palette
  - `<meta name="description">` added

## Verification

- `curl http://localhost:8080/favicon.svg` → `200 image/svg+xml`, 427 bytes
- `curl http://localhost:8080/` contains the new `<link rel="icon">` + both `theme-color` metas
- No code path / build step changed; Vite's `public/` convention handles static serving

## Test plan

- [x] Favicon served
- [x] index.html links it
- [ ] Visual verification on Chrome / Edge / Firefox / Safari tabs after hard-refresh