### PR TITLE
[#28] Image-size guard with downscale-and-retry

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -131,3 +131,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-20 20:55 — Continue / run housekeeping for #29 (`feat/29-scraper-per-icao-chart-types`)
 
 > continue
+
+### 2026-04-20 21:05 — Start image-size guard #28 (`develop`)
+
+> start #28

--- a/services/data-ingestion/app/parser/image_guard.py
+++ b/services/data-ingestion/app/parser/image_guard.py
@@ -1,0 +1,114 @@
+"""Image-size guard for vision provider calls.
+
+User-chosen strategy: send PNGs to Claude/OpenAI exactly as stored on
+disk. Fidelity is preserved by default. Only when the provider returns a
+size-related error do we downscale the image in memory and retry once.
+
+Why this shape
+
+- Preflight downscale would penalise every call, including ones that
+  would have worked fine at full resolution.
+- Claude Sonnet 4.6 vision rejects PNGs over ~8 MP (or ~5 MB base64) with
+  a BadRequestError; GPT-4o silently downscales but re-encodes at lower
+  quality. Both share the same fallback: send smaller, try again.
+- One retry only. If the retry still fails for any reason, the caller's
+  existing fail-closed path handles it — the pipeline never guesses.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from dataclasses import dataclass
+
+from PIL import Image
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_LONG_EDGE = 2048
+
+# Substrings that strongly suggest the error is about the image being too
+# large. We intentionally require BOTH the word "image" AND one of the
+# hints — random BadRequestErrors about prompts, tokens, or formatting
+# must NOT trigger a downscale retry.
+_IMAGE_SIZE_HINTS = (
+    "too large",
+    "too big",
+    "exceeds",
+    "maximum",
+    "too many pixels",
+    "dimensions",
+    "megapixel",
+    "pixel",
+    "image_size_exceeded",
+    "size limit",
+)
+
+
+@dataclass
+class DownscaleResult:
+    png_bytes: bytes
+    original_size: tuple[int, int]
+    new_size: tuple[int, int] | None  # None when no downscale was needed
+
+
+def is_image_size_error(exc: BaseException) -> bool:
+    """Heuristic: does this exception look like a provider-side size rejection?
+
+    Checked against the stringified exception. Requires both ``image`` and
+    at least one size-related hint. Conservative on purpose — a false
+    positive would waste a resample; a false negative simply propagates
+    the original error as today.
+    """
+    msg = str(exc).lower()
+    if "image" not in msg:
+        return False
+    return any(hint in msg for hint in _IMAGE_SIZE_HINTS)
+
+
+def downscale_png(
+    png_bytes: bytes,
+    *,
+    max_long_edge: int = DEFAULT_MAX_LONG_EDGE,
+) -> DownscaleResult:
+    """Resize a PNG so its longest edge fits ``max_long_edge`` pixels.
+
+    Preserves aspect ratio. Uses LANCZOS for quality. If the image is
+    already within bounds, returns the original bytes unchanged and
+    ``new_size=None`` so the caller can short-circuit.
+    """
+    img = Image.open(io.BytesIO(png_bytes))
+    width, height = img.size
+    long_edge = max(width, height)
+
+    if long_edge <= max_long_edge:
+        return DownscaleResult(
+            png_bytes=png_bytes,
+            original_size=(width, height),
+            new_size=None,
+        )
+
+    ratio = max_long_edge / long_edge
+    new_width = max(1, int(width * ratio))
+    new_height = max(1, int(height * ratio))
+
+    resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+
+    # Normalise mode to RGB(A) for reliable PNG re-encoding; input may be P/L/etc.
+    if resized.mode not in ("RGB", "RGBA", "L", "LA"):
+        resized = resized.convert("RGBA" if "A" in resized.mode else "RGB")
+
+    buf = io.BytesIO()
+    resized.save(buf, format="PNG", optimize=True)
+
+    log.info(
+        "image_guard: downscaled %dx%d -> %dx%d (%d -> %d bytes)",
+        width, height, new_width, new_height,
+        len(png_bytes), buf.tell(),
+    )
+
+    return DownscaleResult(
+        png_bytes=buf.getvalue(),
+        original_size=(width, height),
+        new_size=(new_width, new_height),
+    )

--- a/services/data-ingestion/app/parser/providers/claude_vision.py
+++ b/services/data-ingestion/app/parser/providers/claude_vision.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import os
 import time
 from pathlib import Path
 
+from ..image_guard import downscale_png, is_image_size_error
 from ..prompts import load as load_prompt
 from ..usage_tracker import UsageRecord, UsageTracker
 from .base import ExtractionProvider, FieldGroup, ProviderNotConfigured, ProviderResult
+
+log = logging.getLogger(__name__)
 
 
 class ClaudeVisionProvider(ExtractionProvider):
@@ -39,6 +43,43 @@ class ClaudeVisionProvider(ExtractionProvider):
             self._client = Anthropic(api_key=self.api_key)
         return self._client
 
+    def _call_api(self, image_b64: str, prompt_text: str):
+        client = self._get_client()
+        return client.messages.create(
+            model=self.MODEL_ID,
+            max_tokens=4096,
+            system=[
+                {
+                    "type": "text",
+                    "text": prompt_text,
+                    # Prompt caching: system prompt is identical across every
+                    # aerodrome for a given field group. `ephemeral` lets
+                    # Anthropic charge 10 % of the base rate on cache hits
+                    # (5 min TTL) — massively reduces cost of a batch run.
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": image_b64,
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "Return ONLY the JSON object matching the described schema.",
+                        },
+                    ],
+                }
+            ],
+        )
+
     def extract(
         self,
         *,
@@ -54,46 +95,49 @@ class ClaudeVisionProvider(ExtractionProvider):
 
         image_bytes = image_path.read_bytes()
         image_hash = hashlib.sha256(image_bytes).hexdigest()
-        image_b64 = base64.standard_b64encode(image_bytes).decode()
 
-        client = self._get_client()
-        start = time.monotonic()
         request_id: str | None = None
+        start = time.monotonic()
         try:
-            # Prompt caching: the system prompt is identical across every
-            # aerodrome for a given field group. Marking it `ephemeral`
-            # lets Anthropic charge 10 % of the base rate on cache hits
-            # (5 min TTL) — massively reduces cost of a batch run.
-            response = client.messages.create(
-                model=self.MODEL_ID,
-                max_tokens=4096,
-                system=[
-                    {
-                        "type": "text",
-                        "text": prompt_text,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": "image/png",
-                                    "data": image_b64,
-                                },
-                            },
-                            {
-                                "type": "text",
-                                "text": "Return ONLY the JSON object matching the described schema.",
-                            },
-                        ],
-                    }
-                ],
-            )
+            # Attempt 1: send as stored on disk.
+            try:
+                response = self._call_api(
+                    base64.standard_b64encode(image_bytes).decode(),
+                    prompt_text,
+                )
+            except Exception as exc:
+                if not is_image_size_error(exc):
+                    raise
+
+                # Record the oversize failure as its own audit row so the
+                # /usage dashboard shows that a retry was needed.
+                first_latency = int((time.monotonic() - start) * 1000)
+                if self.tracker is not None:
+                    self.tracker.record(UsageRecord(
+                        provider="claude",
+                        model=self.MODEL_ID,
+                        purpose=f"extract:{field_group}",
+                        aerodrome_icao=aerodrome_icao,
+                        source_chart_id=source_chart_id,
+                        latency_ms=first_latency,
+                        success=False,
+                        error_code="image_size_rejected",
+                    ))
+
+                ds = downscale_png(image_bytes)
+                if ds.new_size is None:
+                    # Already within bounds, yet still rejected — no safe retry.
+                    raise
+                log.warning(
+                    "claude: retrying %s after downscale %s -> %s",
+                    image_path.name, ds.original_size, ds.new_size,
+                )
+                start = time.monotonic()  # reset so latency_ms reflects the retry call only
+                response = self._call_api(
+                    base64.standard_b64encode(ds.png_bytes).decode(),
+                    prompt_text,
+                )
+
             latency_ms = int((time.monotonic() - start) * 1000)
             request_id = getattr(response, "id", None)
 

--- a/services/data-ingestion/app/parser/providers/openai_vision.py
+++ b/services/data-ingestion/app/parser/providers/openai_vision.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import os
 import time
 from pathlib import Path
 
+from ..image_guard import downscale_png, is_image_size_error
 from ..prompts import load as load_prompt
 from ..usage_tracker import UsageRecord, UsageTracker
 from .base import ExtractionProvider, FieldGroup, ProviderNotConfigured, ProviderResult
+
+log = logging.getLogger(__name__)
 
 
 class OpenAIVisionProvider(ExtractionProvider):
@@ -38,6 +42,33 @@ class OpenAIVisionProvider(ExtractionProvider):
             self._client = OpenAI(api_key=self.api_key)
         return self._client
 
+    def _call_api(self, image_b64: str, prompt_text: str):
+        client = self._get_client()
+        return client.chat.completions.create(
+            model=self.MODEL_ID,
+            max_tokens=4096,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": prompt_text},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{image_b64}",
+                                "detail": "high",
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "Return ONLY the JSON object matching the described schema.",
+                        },
+                    ],
+                },
+            ],
+        )
+
     def extract(
         self,
         *,
@@ -53,36 +84,46 @@ class OpenAIVisionProvider(ExtractionProvider):
 
         image_bytes = image_path.read_bytes()
         image_hash = hashlib.sha256(image_bytes).hexdigest()
-        image_b64 = base64.standard_b64encode(image_bytes).decode()
 
-        client = self._get_client()
-        start = time.monotonic()
         request_id: str | None = None
+        start = time.monotonic()
         try:
-            response = client.chat.completions.create(
-                model=self.MODEL_ID,
-                max_tokens=4096,
-                response_format={"type": "json_object"},
-                messages=[
-                    {"role": "system", "content": prompt_text},
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/png;base64,{image_b64}",
-                                    "detail": "high",
-                                },
-                            },
-                            {
-                                "type": "text",
-                                "text": "Return ONLY the JSON object matching the described schema.",
-                            },
-                        ],
-                    },
-                ],
-            )
+            # Attempt 1: send as stored on disk.
+            try:
+                response = self._call_api(
+                    base64.standard_b64encode(image_bytes).decode(),
+                    prompt_text,
+                )
+            except Exception as exc:
+                if not is_image_size_error(exc):
+                    raise
+
+                first_latency = int((time.monotonic() - start) * 1000)
+                if self.tracker is not None:
+                    self.tracker.record(UsageRecord(
+                        provider="openai",
+                        model=self.MODEL_ID,
+                        purpose=f"extract:{field_group}",
+                        aerodrome_icao=aerodrome_icao,
+                        source_chart_id=source_chart_id,
+                        latency_ms=first_latency,
+                        success=False,
+                        error_code="image_size_rejected",
+                    ))
+
+                ds = downscale_png(image_bytes)
+                if ds.new_size is None:
+                    raise
+                log.warning(
+                    "openai: retrying %s after downscale %s -> %s",
+                    image_path.name, ds.original_size, ds.new_size,
+                )
+                start = time.monotonic()
+                response = self._call_api(
+                    base64.standard_b64encode(ds.png_bytes).decode(),
+                    prompt_text,
+                )
+
             latency_ms = int((time.monotonic() - start) * 1000)
             request_id = getattr(response, "id", None)
 

--- a/services/data-ingestion/tests/test_parser_image_guard.py
+++ b/services/data-ingestion/tests/test_parser_image_guard.py
@@ -1,0 +1,117 @@
+"""Unit tests for the image-size guard."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from app.parser.image_guard import (
+    DEFAULT_MAX_LONG_EDGE,
+    downscale_png,
+    is_image_size_error,
+)
+
+
+def _make_png(width: int, height: int, *, color: tuple[int, int, int] = (128, 128, 128)) -> bytes:
+    img = Image.new("RGB", (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# is_image_size_error — heuristic detector
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "image too large: 8000x8000 pixels exceeds maximum",
+        "Bad request: image dimensions too big",
+        "image exceeds 1568x1568 pixels",
+        "Image size limit exceeded: 5MB",
+        "too many megapixels in image",
+        "image_size_exceeded",
+    ],
+)
+def test_is_image_size_error_true(message: str):
+    assert is_image_size_error(ValueError(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Invalid API key",
+        "Rate limit exceeded",          # no "image" in message
+        "prompt too long",              # size-ish word but about prompt, not image
+        "Model unavailable",
+        "Connection timeout",
+        "Invalid JSON in response",
+        "",
+    ],
+)
+def test_is_image_size_error_false(message: str):
+    assert is_image_size_error(ValueError(message)) is False
+
+
+def test_is_image_size_error_unrelated_image_error():
+    # Has "image" but no size hint — should NOT trigger retry.
+    assert is_image_size_error(ValueError("failed to decode image")) is False
+
+
+# ---------------------------------------------------------------------------
+# downscale_png — resize behaviour
+# ---------------------------------------------------------------------------
+
+def test_downscale_png_already_small_short_circuits():
+    png = _make_png(100, 100)
+    result = downscale_png(png, max_long_edge=DEFAULT_MAX_LONG_EDGE)
+    assert result.new_size is None
+    assert result.png_bytes is png  # returns the exact input bytes, no re-encode
+    assert result.original_size == (100, 100)
+
+
+def test_downscale_png_shrinks_oversized_landscape():
+    png = _make_png(4000, 3000)
+    result = downscale_png(png, max_long_edge=2048)
+    assert result.original_size == (4000, 3000)
+    assert result.new_size is not None
+    new_w, new_h = result.new_size
+    assert max(new_w, new_h) == 2048
+    # Aspect ratio preserved within 1 px rounding.
+    assert abs((new_w / new_h) - (4000 / 3000)) < 0.01
+
+
+def test_downscale_png_shrinks_oversized_portrait():
+    png = _make_png(2000, 5000)
+    result = downscale_png(png, max_long_edge=2048)
+    assert result.new_size is not None
+    new_w, new_h = result.new_size
+    assert max(new_w, new_h) == 2048
+    assert new_h > new_w  # still portrait
+
+
+def test_downscale_png_returns_valid_png():
+    """The downscaled bytes must be a decodable PNG."""
+    png = _make_png(3000, 2000)
+    result = downscale_png(png, max_long_edge=1024)
+    assert result.new_size is not None
+    # Round-trip: decode the output and check dimensions match.
+    out = Image.open(io.BytesIO(result.png_bytes))
+    assert out.format == "PNG"
+    assert out.size == result.new_size
+
+
+def test_downscale_png_at_boundary_not_resized():
+    # Image exactly at max_long_edge should NOT be resized.
+    png = _make_png(2048, 1024)
+    result = downscale_png(png, max_long_edge=2048)
+    assert result.new_size is None
+
+
+def test_downscale_png_custom_max_edge():
+    png = _make_png(4000, 4000)
+    result = downscale_png(png, max_long_edge=1000)
+    assert result.new_size == (1000, 1000)

--- a/services/data-ingestion/tests/test_parser_provider_retry.py
+++ b/services/data-ingestion/tests/test_parser_provider_retry.py
@@ -1,0 +1,290 @@
+"""Tests that both vision providers retry once after an image-size rejection.
+
+These tests do not hit real APIs. They replace the provider's `_call_api`
+method with a scripted sequence of fake responses / exceptions, and
+verify the retry wiring + audit-row recording.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from PIL import Image
+
+from app.parser.providers.claude_vision import ClaudeVisionProvider
+from app.parser.providers.openai_vision import OpenAIVisionProvider
+from app.parser.usage_tracker import UsageRecord
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeTracker:
+    """Collects UsageRecord calls instead of persisting them."""
+
+    def __init__(self) -> None:
+        self.records: list[UsageRecord] = []
+
+    def record(self, usage: UsageRecord) -> int | None:
+        self.records.append(usage)
+        return len(self.records)
+
+
+# -- Claude response shape --
+
+@dataclass
+class _ClaudeUsage:
+    input_tokens: int = 1000
+    output_tokens: int = 50
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+
+@dataclass
+class _ClaudeBlock:
+    type: str
+    text: str
+
+
+@dataclass
+class _ClaudeResponse:
+    id: str = "msg_fake"
+    usage: _ClaudeUsage = None
+    content: list = None
+
+    def __post_init__(self):
+        if self.usage is None:
+            self.usage = _ClaudeUsage()
+        if self.content is None:
+            self.content = [_ClaudeBlock(type="text", text='{"latitude_deg": null}')]
+
+
+# -- OpenAI response shape --
+
+@dataclass
+class _OpenAIDetails:
+    cached_tokens: int = 0
+
+
+@dataclass
+class _OpenAIUsage:
+    prompt_tokens: int = 1000
+    completion_tokens: int = 50
+    prompt_tokens_details: _OpenAIDetails = None
+
+    def __post_init__(self):
+        if self.prompt_tokens_details is None:
+            self.prompt_tokens_details = _OpenAIDetails()
+
+
+@dataclass
+class _OpenAIMessage:
+    content: str = '{"latitude_deg": null}'
+
+
+@dataclass
+class _OpenAIChoice:
+    message: _OpenAIMessage = None
+
+    def __post_init__(self):
+        if self.message is None:
+            self.message = _OpenAIMessage()
+
+
+@dataclass
+class _OpenAIResponse:
+    id: str = "chatcmpl_fake"
+    usage: _OpenAIUsage = None
+    choices: list = None
+
+    def __post_init__(self):
+        if self.usage is None:
+            self.usage = _OpenAIUsage()
+        if self.choices is None:
+            self.choices = [_OpenAIChoice()]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_oversized_png(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (3000, 2000), (10, 10, 10))
+    path = tmp_path / "oversized.png"
+    img.save(path, format="PNG")
+    return path
+
+
+def _write_small_png(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (100, 100), (10, 10, 10))
+    path = tmp_path / "small.png"
+    img.save(path, format="PNG")
+    return path
+
+
+def _scripted(sequence: list):
+    """Return a callable that yields the next item on each call.
+
+    Items that are Exception instances are raised; everything else is returned.
+    """
+    it = iter(sequence)
+
+    def _call(*args, **kwargs):
+        item = next(it)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Claude provider tests
+# ---------------------------------------------------------------------------
+
+def test_claude_success_first_try_records_one_success(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = ClaudeVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(provider, "_call_api", _scripted([_ClaudeResponse()]))
+
+    result = provider.extract(
+        image_path=_write_small_png(tmp_path),
+        field_group="geo",
+        aerodrome_icao="EDDM",
+    )
+    assert result.model_version == ClaudeVisionProvider.MODEL_ID
+    assert len(tracker.records) == 1
+    assert tracker.records[0].success is True
+
+
+def test_claude_size_error_triggers_downscale_and_retry(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = ClaudeVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(
+        provider,
+        "_call_api",
+        _scripted([
+            ValueError("image too large: exceeds 8000x8000 pixels"),
+            _ClaudeResponse(),
+        ]),
+    )
+
+    result = provider.extract(
+        image_path=_write_oversized_png(tmp_path),
+        field_group="geo",
+        aerodrome_icao="EDDM",
+    )
+    assert result.model_version == ClaudeVisionProvider.MODEL_ID
+    # Two audit rows: the oversize failure + the retry success.
+    assert len(tracker.records) == 2
+    assert tracker.records[0].success is False
+    assert tracker.records[0].error_code == "image_size_rejected"
+    assert tracker.records[1].success is True
+
+
+def test_claude_non_size_error_does_not_retry(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = ClaudeVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(
+        provider,
+        "_call_api",
+        _scripted([RuntimeError("rate limit exceeded")]),
+    )
+
+    with pytest.raises(RuntimeError, match="rate limit"):
+        provider.extract(
+            image_path=_write_small_png(tmp_path),
+            field_group="geo",
+        )
+    # One audit row, the generic failure. No retry row.
+    assert len(tracker.records) == 1
+    assert tracker.records[0].success is False
+    assert tracker.records[0].error_code == "RuntimeError"
+
+
+def test_claude_size_error_but_already_small_raises(tmp_path, monkeypatch):
+    """Provider claims size error but image is within bounds — no safe retry."""
+    tracker = FakeTracker()
+    provider = ClaudeVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(
+        provider,
+        "_call_api",
+        _scripted([ValueError("image size exceeds maximum")]),
+    )
+
+    with pytest.raises(ValueError, match="image size"):
+        provider.extract(
+            image_path=_write_small_png(tmp_path),  # already small
+            field_group="geo",
+        )
+    # First-failure row was recorded before the downscale short-circuited.
+    # Then the outer except records a second failure row with the exc type.
+    assert len(tracker.records) == 2
+    assert tracker.records[0].error_code == "image_size_rejected"
+    assert tracker.records[1].error_code == "ValueError"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider tests (symmetric wiring; same expectations)
+# ---------------------------------------------------------------------------
+
+def test_openai_success_first_try_records_one_success(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = OpenAIVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(provider, "_call_api", _scripted([_OpenAIResponse()]))
+
+    result = provider.extract(
+        image_path=_write_small_png(tmp_path),
+        field_group="geo",
+        aerodrome_icao="EDDM",
+    )
+    assert result.model_version == OpenAIVisionProvider.MODEL_ID
+    assert len(tracker.records) == 1
+    assert tracker.records[0].success is True
+
+
+def test_openai_size_error_triggers_downscale_and_retry(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = OpenAIVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(
+        provider,
+        "_call_api",
+        _scripted([
+            ValueError("image dimensions exceed 4096 pixels"),
+            _OpenAIResponse(),
+        ]),
+    )
+
+    result = provider.extract(
+        image_path=_write_oversized_png(tmp_path),
+        field_group="geo",
+        aerodrome_icao="EDDM",
+    )
+    assert result.model_version == OpenAIVisionProvider.MODEL_ID
+    assert len(tracker.records) == 2
+    assert tracker.records[0].success is False
+    assert tracker.records[0].error_code == "image_size_rejected"
+    assert tracker.records[1].success is True
+
+
+def test_openai_non_size_error_does_not_retry(tmp_path, monkeypatch):
+    tracker = FakeTracker()
+    provider = OpenAIVisionProvider(api_key="fake-key", tracker=tracker)
+    monkeypatch.setattr(
+        provider,
+        "_call_api",
+        _scripted([RuntimeError("rate limit exceeded")]),
+    )
+
+    with pytest.raises(RuntimeError, match="rate limit"):
+        provider.extract(
+            image_path=_write_small_png(tmp_path),
+            field_group="geo",
+        )
+    assert len(tracker.records) == 1
+    assert tracker.records[0].error_code == "RuntimeError"


### PR DESCRIPTION
Closes #28.

## Summary

- New `app/parser/image_guard.py`: `is_image_size_error(exc)` heuristic + `downscale_png(bytes, max_long_edge=2048)` LANCZOS resize.
- Both vision providers (Claude, OpenAI) now send PNGs as-stored by default. On a size-related error, the oversize attempt is recorded as a failure audit row (`error_code="image_size_rejected"`), the image is downscaled in memory, and the call is retried once.
- Non-size errors bubble up with the existing fail-closed behaviour — no silent retries on rate limits, auth errors, etc.

## Why this shape

User-chosen strategy in #28: preflight downscale would penalise every call including ones that would have worked fine at full fidelity. Sending as-stored and only downscaling reactively preserves image quality by default and keeps the audit trail honest about which inputs were oversized.

Two audit rows are produced for a retry path (oversize failure + retry success) so the `/usage` dashboard makes the retry visible without a schema change.

## Services affected

- `data-ingestion` — no Docker rebuild needed (Pillow 11.1 already in the image; code mounted via volume).

## Test plan

- [x] 20 image_guard unit tests (detector + resize behaviour + edge cases)
- [x] 7 provider retry tests with mocked SDK responses (success / size-error-retry / non-size-error / already-small edge case — for both Claude and OpenAI)
- [x] Full data-ingestion suite: 139 passed, no regressions
- [ ] Post-merge: batch run on real EDDM PNGs to observe the retry path live in the `/usage` dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)