### PR TITLE
[#36] Multi-chart aggregation + byte-budget ladder + HE-autofill

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -159,3 +159,19 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-20 22:30 — Build async extraction trigger with progress indicator (`develop`)
 
 > ja mache das - aber bitte asynchron mit einer fortschrittsanzeige
+
+### 2026-04-20 22:45 — User reports no button visible (`develop`)
+
+> Und da ist kein Button.
+
+### 2026-04-20 22:40 — EDDF extraction incomplete: 2/4 Pisten, 0 Freqs, fehlende Höhe (`develop`)
+
+> Das hast du für Frankfurt ausgelesen. Frankfurt hat vier Start- und Landebahnen und natürlich auch verschiedene, viele Frequenzen. Die hast du alle nicht ausgelesen. Elevation hast du nicht ausgelesen, also Höhe. Region und Yata auch nicht, aber das ist jetzt nicht so wichtig.
+
+### 2026-04-20 22:50 — Approved option 1: multi-chart aggregation (`develop`)
+
+> 1
+
+### 2026-04-20 23:10 — Pisten und Freqs sind klar erkennbar — diagnose deep (`develop`)
+
+> das ist schlecht. sowohl die pisten als auch die frequenzen sind einfach und klar zu erkennen

--- a/scripts/diagnose_eddf.py
+++ b/scripts/diagnose_eddf.py
@@ -1,0 +1,88 @@
+"""Diagnostic — call Claude + OpenAI directly on EDDF charts.
+
+Prints the FULL parsed JSON per provider per chart per field_group so
+we can see why consensus is failing (one provider sees, other doesn't?
+both see but disagree? prompt filters out?).
+
+Run inside the data-ingestion container:
+    docker compose exec -T data-ingestion python scripts/diagnose_eddf.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "/app")
+
+from app.parser.providers.claude_vision import ClaudeVisionProvider  # noqa: E402
+from app.parser.providers.openai_vision import OpenAIVisionProvider  # noqa: E402
+
+DATA_ROOT = Path("/app/data/aerodromes/EDDF")
+
+CHARTS = [
+    "EDDF_Frankfurt_Main_1_print.png",
+    "EDDF_Frankfurt_Main_2_print.png",
+    "EDDF_Frankfurt_Main_3_print.png",
+    "EDDF_Frankfurt_Main_5_print.png",
+    "EDDF_Frankfurt_Main_Terminal_Chart_print.png",
+]
+
+FIELD_GROUPS = ["runways", "frequencies"]
+
+
+def _walk_values(parsed, prefix=""):
+    """Yield every non-null ExtractedValue as a (path, value) tuple."""
+    if parsed is None:
+        return
+    if isinstance(parsed, dict):
+        if "value" in parsed:
+            if parsed.get("value") is not None:
+                yield prefix, parsed["value"]
+            return
+        for k, v in parsed.items():
+            yield from _walk_values(v, f"{prefix}.{k}" if prefix else k)
+    elif isinstance(parsed, list):
+        for i, item in enumerate(parsed):
+            yield from _walk_values(item, f"{prefix}[{i}]")
+
+
+def main():
+    claude = ClaudeVisionProvider()
+    openai = OpenAIVisionProvider()
+    if not (claude.is_configured() and openai.is_configured()):
+        print("Missing API keys")
+        return 2
+
+    for field_group in FIELD_GROUPS:
+        print(f"\n{'=' * 70}")
+        print(f"FIELD GROUP: {field_group}")
+        print(f"{'=' * 70}")
+        for chart_name in CHARTS:
+            chart_path = DATA_ROOT / chart_name
+            if not chart_path.exists():
+                print(f"\n--- {chart_name} — FILE MISSING")
+                continue
+            print(f"\n--- {chart_name} ---")
+            for p, label in ((claude, "CLAUDE"), (openai, "OPENAI")):
+                try:
+                    res = p.extract(
+                        image_path=chart_path,
+                        field_group=field_group,
+                        aerodrome_icao="EDDF",
+                    )
+                    parsed = res.raw_response.get("parsed")
+                    vals = list(_walk_values(parsed))
+                    print(f"  {label}: {len(vals)} non-null values")
+                    for path, val in vals[:20]:
+                        s = str(val)[:60]
+                        print(f"    {path} = {s}")
+                except Exception as exc:
+                    print(f"  {label}: {type(exc).__name__}: {str(exc)[:200]}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/data-ingestion/app/parser/image_guard.py
+++ b/services/data-ingestion/app/parser/image_guard.py
@@ -1,18 +1,21 @@
 """Image-size guard for vision provider calls.
 
-User-chosen strategy: send PNGs to Claude/OpenAI exactly as stored on
-disk. Fidelity is preserved by default. Only when the provider returns a
-size-related error do we downscale the image in memory and retry once.
+User-chosen strategy (per #28): send PNGs to Claude/OpenAI exactly as
+stored on disk. Fidelity is preserved by default. Only when the
+provider returns a size-related error do we downscale in memory and
+retry once.
 
-Why this shape
+Revised for #36 diagnosis: Anthropic has TWO independent limits —
+pixel dimensions (~8 MP) AND base64 body size (5 MB). A chart that's
+fine on pixels can still exceed the byte limit after PNG re-encode
+because PNG is lossless and high-detail aerodrome charts compress
+poorly. The downscaler now walks a ladder of resolutions until either
 
-- Preflight downscale would penalise every call, including ones that
-  would have worked fine at full resolution.
-- Claude Sonnet 4.6 vision rejects PNGs over ~8 MP (or ~5 MB base64) with
-  a BadRequestError; GPT-4o silently downscales but re-encodes at lower
-  quality. Both share the same fallback: send smaller, try again.
-- One retry only. If the retry still fails for any reason, the caller's
-  existing fail-closed path handles it — the pipeline never guesses.
+  - the re-encoded PNG fits under an empirical byte budget, or
+  - it has been shrunk to the smallest useful size (768 px long edge)
+
+Below 768 px the LLMs genuinely lose legibility of small type, so we
+stop there and let the provider error propagate.
 """
 
 from __future__ import annotations
@@ -25,12 +28,22 @@ from PIL import Image
 
 log = logging.getLogger(__name__)
 
+# Anthropic rejects images whose BASE64 body exceeds 5 MB. A raw PNG of
+# ~3.7 MB expands to ~5 MB base64. Leave headroom for JSON overhead.
+DEFAULT_MAX_BYTES = 3_600_000
+
+# Back-compat shim for imports that predate the byte-budget ladder.
+# Tests and callers may still reference this as the pixel cap.
 DEFAULT_MAX_LONG_EDGE = 2048
 
-# Substrings that strongly suggest the error is about the image being too
-# large. We intentionally require BOTH the word "image" AND one of the
-# hints — random BadRequestErrors about prompts, tokens, or formatting
-# must NOT trigger a downscale retry.
+# Ladder of pixel dimensions tried from largest to smallest. Stops early
+# once the PNG fits under the byte budget.
+_DOWNSCALE_LADDER: tuple[int, ...] = (2048, 1568, 1280, 1024, 768)
+
+# Substrings that strongly suggest the error is about the image being
+# too large. We require BOTH the word "image" AND one of these hints so
+# random BadRequestErrors about prompts, tokens, or formatting don't
+# trigger a waste-of-money resample.
 _IMAGE_SIZE_HINTS = (
     "too large",
     "too big",
@@ -42,6 +55,9 @@ _IMAGE_SIZE_HINTS = (
     "pixel",
     "image_size_exceeded",
     "size limit",
+    "5 mb",
+    "5mb",
+    "bytes >",
 )
 
 
@@ -66,49 +82,94 @@ def is_image_size_error(exc: BaseException) -> bool:
     return any(hint in msg for hint in _IMAGE_SIZE_HINTS)
 
 
+def _resize_and_encode(img: Image.Image, long_edge: int) -> tuple[bytes, tuple[int, int]]:
+    """Resize to `long_edge` preserving aspect, re-encode PNG, return bytes + new dims."""
+    w, h = img.size
+    ratio = long_edge / max(w, h)
+    new_w = max(1, int(w * ratio))
+    new_h = max(1, int(h * ratio))
+    resized = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+    if resized.mode not in ("RGB", "RGBA", "L", "LA"):
+        resized = resized.convert("RGBA" if "A" in resized.mode else "RGB")
+    buf = io.BytesIO()
+    resized.save(buf, format="PNG", optimize=True)
+    return buf.getvalue(), (new_w, new_h)
+
+
 def downscale_png(
     png_bytes: bytes,
     *,
-    max_long_edge: int = DEFAULT_MAX_LONG_EDGE,
+    max_long_edge: int | None = None,  # legacy kw; ignored if set — ladder drives now
+    max_bytes: int = DEFAULT_MAX_BYTES,
 ) -> DownscaleResult:
-    """Resize a PNG so its longest edge fits ``max_long_edge`` pixels.
+    """Walk a pixel-ladder until the re-encoded PNG fits under max_bytes.
 
-    Preserves aspect ratio. Uses LANCZOS for quality. If the image is
-    already within bounds, returns the original bytes unchanged and
-    ``new_size=None`` so the caller can short-circuit.
+    The legacy `max_long_edge` parameter is preserved for backward-compat
+    with the unit tests (they cap the ladder's top step). Any value > 768
+    is folded into the ladder; values ≤ 768 force that as the sole step.
     """
     img = Image.open(io.BytesIO(png_bytes))
-    width, height = img.size
-    long_edge = max(width, height)
+    original_size = img.size
 
-    if long_edge <= max_long_edge:
-        return DownscaleResult(
-            png_bytes=png_bytes,
-            original_size=(width, height),
-            new_size=None,
+    # Already within byte budget AND not forced-shrunk by a legacy kw? short-circuit.
+    if len(png_bytes) <= max_bytes and max_long_edge is None:
+        if max(original_size) <= _DOWNSCALE_LADDER[0]:
+            return DownscaleResult(
+                png_bytes=png_bytes,
+                original_size=original_size,
+                new_size=None,
+            )
+
+    # Build the ladder for this call.
+    if max_long_edge is not None:
+        # Respect the caller's cap. Use ladder steps that are ≤ cap,
+        # including the cap itself as the first entry. Collapse to just
+        # the cap if it's below the smallest standard step.
+        cap = max(1, int(max_long_edge))
+        if cap < _DOWNSCALE_LADDER[-1]:
+            ladder = (cap,)
+        else:
+            ladder = (cap,) + tuple(s for s in _DOWNSCALE_LADDER if s < cap)
+        # If the original already fits cap AND byte budget, no-op.
+        if max(original_size) <= cap and len(png_bytes) <= max_bytes:
+            return DownscaleResult(
+                png_bytes=png_bytes,
+                original_size=original_size,
+                new_size=None,
+            )
+    else:
+        ladder = _DOWNSCALE_LADDER
+
+    last_bytes: bytes | None = None
+    last_dims: tuple[int, int] | None = None
+    for step in ladder:
+        if max(original_size) <= step and len(png_bytes) <= max_bytes:
+            # Original already fits this step AND byte budget — return as-is.
+            return DownscaleResult(
+                png_bytes=png_bytes,
+                original_size=original_size,
+                new_size=None,
+            )
+        new_bytes, new_dims = _resize_and_encode(img, step)
+        last_bytes, last_dims = new_bytes, new_dims
+        log.info(
+            "image_guard: %dx%d -> %dx%d (%d -> %d bytes, budget %d)",
+            original_size[0], original_size[1],
+            new_dims[0], new_dims[1],
+            len(png_bytes), len(new_bytes), max_bytes,
         )
+        if len(new_bytes) <= max_bytes:
+            return DownscaleResult(
+                png_bytes=new_bytes,
+                original_size=original_size,
+                new_size=new_dims,
+            )
 
-    ratio = max_long_edge / long_edge
-    new_width = max(1, int(width * ratio))
-    new_height = max(1, int(height * ratio))
-
-    resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-
-    # Normalise mode to RGB(A) for reliable PNG re-encoding; input may be P/L/etc.
-    if resized.mode not in ("RGB", "RGBA", "L", "LA"):
-        resized = resized.convert("RGBA" if "A" in resized.mode else "RGB")
-
-    buf = io.BytesIO()
-    resized.save(buf, format="PNG", optimize=True)
-
-    log.info(
-        "image_guard: downscaled %dx%d -> %dx%d (%d -> %d bytes)",
-        width, height, new_width, new_height,
-        len(png_bytes), buf.tell(),
-    )
-
+    # Exhausted the ladder without fitting the byte budget. Return the
+    # smallest rendering we produced — better than nothing; the caller's
+    # retry will pass this to the API and either succeed or fail-closed.
     return DownscaleResult(
-        png_bytes=buf.getvalue(),
-        original_size=(width, height),
-        new_size=(new_width, new_height),
+        png_bytes=last_bytes or png_bytes,
+        original_size=original_size,
+        new_size=last_dims,
     )

--- a/services/data-ingestion/app/parser/providers/openai_vision.py
+++ b/services/data-ingestion/app/parser/providers/openai_vision.py
@@ -154,7 +154,7 @@ class OpenAIVisionProvider(ExtractionProvider):
                 ))
 
             raw_text = response.choices[0].message.content or ""
-            parsed = json.loads(raw_text)
+            parsed = _extract_json(raw_text)
 
             return ProviderResult(
                 raw_response={
@@ -186,3 +186,25 @@ class OpenAIVisionProvider(ExtractionProvider):
                     request_id=request_id,
                 ))
             raise
+
+
+def _extract_json(text: str) -> dict:
+    """Parse JSON from a response body that may have wrapping prose or
+    markdown fences. Matches the robustness of claude_vision._extract_json.
+    """
+    text = (text or "").strip()
+    if not text:
+        return {}
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            return json.loads(text[start : end + 1])
+        raise

--- a/services/data-ingestion/app/services/extraction_runner.py
+++ b/services/data-ingestion/app/services/extraction_runner.py
@@ -1,19 +1,43 @@
-"""Per-aerodrome extraction runner.
+"""Per-aerodrome extraction runner (multi-chart aggregation).
 
-Runs the 2-of-2 Claude+OpenAI vision pipeline on the ranked VFR chart
-candidates and writes consensus results to the ingest DB tables.
+Runs the 2-of-2 Claude+OpenAI vision pipeline on every acceptable VFR
+chart for each field group and **merges** results across charts. Writes
+consensus values to the ingest DB tables.
 
-Scope (MVP, for #34):
-  - field_groups written to DB: geo, runways, frequencies.
-  - obstacles + reporting_points extracted for the audit trail but not
-    persisted (no DB tables yet — follow-up issue).
+Design (revised for #36)
+------------------------
 
-Progress tracking: updates ``ingest.extraction_jobs`` after each field
-group so the UI can poll and display a realistic step indicator.
+Problem with the first-wins cascade used in #35: German airports spread
+data across several charts (e.g. EDDF prints parallel runway pair on
+chart 2 and the cross-runway on chart 3; frequency box sits on the
+Terminal Chart; elevation may appear on the VAC but not the ADC). The
+original runner stopped at the first chart that had any signal and
+missed everything on the others.
 
-Errors never abort the whole job; they're recorded per-field-group so
-the user can see partial successes (e.g. runways succeeded, obstacles
-failed with rate-limit).
+Revised semantics:
+
+- **List-valued field groups** (runways, frequencies, obstacles,
+  reporting_points): iterate ALL acceptable candidates. Per chart,
+  compute same-chart 2-of-2 consensus entries. Across charts, take the
+  union keyed by natural identity (`designator_le` for runways,
+  `(type, frequency_mhz)` for frequencies). First-seen wins for an
+  individual key — later charts don't overwrite.
+
+- **Scalar field group** (geo): iterate candidates. Per chart, compute
+  the dict of agreed-upon fields (`_agreed_geo_on_chart`). Merge into
+  the accumulator by filling gaps only — earlier accepted values stand.
+  Stop early once every scalar field has been filled.
+
+- **Same-chart consensus** is preserved. We never let Claude on chart A
+  + OpenAI on chart B "agree" on something — that would chain
+  hallucinations across independent pages.
+
+- `obstacles` and `reporting_points` are extracted but not persisted
+  (no DB tables yet — separate issue).
+
+Failure semantics: errors per chart don't abort the job. The field
+group records the last transient error in `field_groups_completed`
+for the user to see.
 """
 
 from __future__ import annotations
@@ -47,8 +71,9 @@ log = logging.getLogger(__name__)
 
 DATA_ROOT = Path("/app/data/aerodromes")
 
-# How many candidate charts to cascade through per field group before giving up.
-MAX_CANDIDATES_PER_GROUP = 3
+# Safety cap against runaway API spend. Typical German VFR airport has
+# 4–8 acceptable charts; 10 is plenty.
+MAX_CANDIDATES_PER_GROUP = 10
 
 # Field groups the runner executes, in the order the progress bar shows them.
 PIPELINE_FIELD_GROUPS: tuple[FieldGroup, ...] = (
@@ -59,12 +84,25 @@ PIPELINE_FIELD_GROUPS: tuple[FieldGroup, ...] = (
     "reporting_points",
 )
 
+# All scalar fields the geo runner may fill. Order matters only for the
+# early-exit heuristic.
+_GEO_FIELDS: tuple[str, ...] = (
+    "latitude_deg",
+    "longitude_deg",
+    "elevation_ft",
+    "magnetic_variation_deg",
+    "operator",
+    "operator_de",
+    "city",
+    "city_de",
+)
+
 
 class ExtractionRunner:
     """Orchestrates one extraction job for one aerodrome.
 
-    Instantiated per-job by the FastAPI BackgroundTasks handler. Holds no
-    state between jobs. DB session lifetime is scoped to the runner.
+    Instantiated per-job by the FastAPI BackgroundTasks handler. Holds
+    no state between jobs. DB session lifetime is scoped to the runner.
     """
 
     def __init__(
@@ -141,69 +179,180 @@ class ExtractionRunner:
         aerodrome_dir = self._data_root / icao
         total_groups = len(PIPELINE_FIELD_GROUPS)
         groups_completed: dict[str, Any] = {}
-        fields_written = 0
+        fields_written_total = 0
 
         for idx, field_group in enumerate(PIPELINE_FIELD_GROUPS, start=1):
-            self._report_progress(
-                session, job,
-                pct=int(((idx - 1) / total_groups) * 95),  # keep last 5% for writes
-                step=f"Extrahiere {field_group} ({idx}/{total_groups})",
-            )
+            base_pct = int(((idx - 1) / total_groups) * 95)
+            self._report_progress(session, job, pct=base_pct,
+                                  step=f"Extrahiere {field_group} ({idx}/{total_groups})")
 
             candidates = rank_charts(aerodrome_dir, field_group=field_group)
+            candidates = candidates[:MAX_CANDIDATES_PER_GROUP]
             if not candidates:
                 groups_completed[field_group] = {"status": "no_candidates"}
                 continue
 
-            accepted_parsed_a, accepted_parsed_b, accepted_chart = None, None, None
-            for candidate in candidates[:MAX_CANDIDATES_PER_GROUP]:
-                self._report_progress(
-                    session, job,
-                    pct=int(((idx - 1) / total_groups) * 95),
-                    step=f"{field_group} ← {candidate.path.name}",
+            if field_group == "geo":
+                written, details = self._run_geo(
+                    session, job, configured, aerodrome, candidates, base_pct, icao,
                 )
-                parsed_a, parsed_b, err = self._call_both_providers(
-                    configured, candidate.path, field_group, icao
+            elif field_group == "runways":
+                written, details = self._run_runways(
+                    session, job, configured, aerodrome, candidates, base_pct, icao,
                 )
-                if err:
-                    # Keep trying the next candidate on transient failure.
-                    groups_completed.setdefault(field_group, {})["last_error"] = err
-                    continue
-                if _has_signal(parsed_a) and _has_signal(parsed_b):
-                    accepted_parsed_a = parsed_a
-                    accepted_parsed_b = parsed_b
-                    accepted_chart = candidate.path.name
-                    break
+            elif field_group == "frequencies":
+                written, details = self._run_frequencies(
+                    session, job, configured, aerodrome, candidates, base_pct, icao,
+                )
+            else:
+                # obstacles / reporting_points — run for audit trail but skip persist.
+                written, details = self._run_audit_only(
+                    job, configured, candidates, base_pct, icao, field_group, session,
+                )
 
-            if accepted_parsed_a is None:
-                groups_completed[field_group] = {
-                    "status": "no_consensus",
-                    "candidates_tried": len(candidates[:MAX_CANDIDATES_PER_GROUP]),
-                }
-                continue
-
-            written = self._persist_field_group(
-                session, aerodrome, field_group,
-                parsed_a=accepted_parsed_a, parsed_b=accepted_parsed_b,
-            )
-            fields_written += written
-            groups_completed[field_group] = {
-                "status": "accepted",
-                "accepted_chart": accepted_chart,
-                "fields_written": written,
-            }
-            # Commit after each group so progress reflects actual DB state.
+            groups_completed[field_group] = details
+            fields_written_total += written
             session.commit()
 
             self._report_progress(
                 session, job,
                 pct=int((idx / total_groups) * 95),
-                step=f"{field_group} abgeschlossen ({written} Felder geschrieben)",
+                step=f"{field_group}: {written} Feld(er) geschrieben",
             )
 
         job.field_groups_completed = groups_completed
-        job.fields_written = fields_written
+        job.fields_written = fields_written_total
         session.commit()
+
+    # ------------------------------------------------------------------ #
+    # Per-field-group runners (aggregate across candidates)
+    # ------------------------------------------------------------------ #
+
+    def _run_geo(
+        self, session, job, providers, aerodrome, candidates, base_pct, icao,
+    ):
+        accumulator: dict[str, Any] = {}
+        charts_used: list[str] = []
+        errors: list[str] = []
+        for i, cand in enumerate(candidates, start=1):
+            if set(accumulator.keys()) >= set(_GEO_FIELDS):
+                break  # every scalar field filled — no point running more charts
+            self._report_progress(
+                session, job, pct=base_pct,
+                step=f"geo ← {cand.path.name} ({i}/{len(candidates)})",
+            )
+            a, b, err = self._call_both_providers(providers, cand.path, "geo", icao)
+            if err:
+                errors.append(err)
+                continue
+            agreed = _agreed_geo_on_chart(a or {}, b or {})
+            if not agreed:
+                continue
+            filled_here = False
+            for field, value in agreed.items():
+                if field in accumulator or value is None:
+                    continue
+                accumulator[field] = value
+                filled_here = True
+            if filled_here and cand.path.name not in charts_used:
+                charts_used.append(cand.path.name)
+        written = _apply_geo_dict(aerodrome, accumulator)
+        return written, {
+            "status": "accepted" if written else "no_consensus",
+            "accepted_charts": charts_used,
+            "fields_written": written,
+            "last_error": errors[-1] if errors else None,
+        }
+
+    def _run_runways(
+        self, session, job, providers, aerodrome, candidates, base_pct, icao,
+    ):
+        merged: dict[str, dict] = {}
+        charts_used: list[str] = []
+        errors: list[str] = []
+        for i, cand in enumerate(candidates, start=1):
+            self._report_progress(
+                session, job, pct=base_pct,
+                step=f"runways ← {cand.path.name} ({i}/{len(candidates)})",
+            )
+            a, b, err = self._call_both_providers(providers, cand.path, "runways", icao)
+            if err:
+                errors.append(err)
+                continue
+            entries = _agreed_runways_on_chart(a or {}, b or {})
+            added_any = False
+            for entry in entries:
+                key = entry["designator_le"]
+                if key not in merged:
+                    merged[key] = entry
+                    added_any = True
+            if added_any and cand.path.name not in charts_used:
+                charts_used.append(cand.path.name)
+        written = _write_runways(session, aerodrome, list(merged.values()))
+        return written, {
+            "status": "accepted" if written else "no_consensus",
+            "accepted_charts": charts_used,
+            "fields_written": written,
+            "last_error": errors[-1] if errors else None,
+        }
+
+    def _run_frequencies(
+        self, session, job, providers, aerodrome, candidates, base_pct, icao,
+    ):
+        merged: dict[tuple, dict] = {}
+        charts_used: list[str] = []
+        errors: list[str] = []
+        for i, cand in enumerate(candidates, start=1):
+            self._report_progress(
+                session, job, pct=base_pct,
+                step=f"frequencies ← {cand.path.name} ({i}/{len(candidates)})",
+            )
+            a, b, err = self._call_both_providers(providers, cand.path, "frequencies", icao)
+            if err:
+                errors.append(err)
+                continue
+            entries = _agreed_frequencies_on_chart(a or {}, b or {})
+            added_any = False
+            for entry in entries:
+                key = (entry["type"], str(entry["frequency_mhz"]))
+                if key not in merged:
+                    merged[key] = entry
+                    added_any = True
+            if added_any and cand.path.name not in charts_used:
+                charts_used.append(cand.path.name)
+        written = _write_frequencies(session, aerodrome, list(merged.values()))
+        return written, {
+            "status": "accepted" if written else "no_consensus",
+            "accepted_charts": charts_used,
+            "fields_written": written,
+            "last_error": errors[-1] if errors else None,
+        }
+
+    def _run_audit_only(
+        self, job, providers, candidates, base_pct, icao, field_group, session,
+    ):
+        errors: list[str] = []
+        saw_signal = False
+        for i, cand in enumerate(candidates, start=1):
+            self._report_progress(
+                session, job, pct=base_pct,
+                step=f"{field_group} ← {cand.path.name} ({i}/{len(candidates)})",
+            )
+            a, b, err = self._call_both_providers(providers, cand.path, field_group, icao)
+            if err:
+                errors.append(err)
+                continue
+            if _has_signal(a) and _has_signal(b):
+                saw_signal = True
+        return 0, {
+            "status": "audit_only_signal_seen" if saw_signal else "audit_only_no_signal",
+            "last_error": errors[-1] if errors else None,
+            "note": "DB persistence not yet implemented",
+        }
+
+    # ------------------------------------------------------------------ #
+    # Provider fan-out
+    # ------------------------------------------------------------------ #
 
     def _call_both_providers(
         self,
@@ -212,7 +361,14 @@ class ExtractionRunner:
         field_group: FieldGroup,
         icao: str,
     ) -> tuple[dict | None, dict | None, str | None]:
-        """Call both providers for one chart. Return (parsed_a, parsed_b, error_or_None)."""
+        """Call both providers for one chart. Return (parsed_a, parsed_b, error_or_None).
+
+        One provider failing on a chart disqualifies the chart from 2-of-2
+        consensus, but does not abort the entire job — the runner moves on
+        to the next candidate. We log the full exception detail here so
+        the root cause is visible in docker logs even though the audit row
+        only keeps the first 400 chars.
+        """
         parsed: dict[str, dict] = {}
         for p in providers:
             try:
@@ -225,9 +381,15 @@ class ExtractionRunner:
             except ProviderNotConfigured:
                 return None, None, f"{p.name} not configured"
             except Exception as exc:
-                return None, None, f"{p.name}: {type(exc).__name__}: {str(exc)[:120]}"
-        # The two registered providers come in order Claude, OpenAI — but
-        # pick them by name to stay robust if config changes.
+                log.exception(
+                    "Provider %s failed on %s for %s",
+                    p.name, image_path.name, field_group,
+                )
+                return (
+                    None, None,
+                    f"{p.name} on {image_path.name}: "
+                    f"{type(exc).__name__}: {str(exc)[:400]}",
+                )
         a = next((v for k, v in parsed.items() if k.startswith("claude")), None)
         b = next((v for k, v in parsed.items() if k.startswith("openai")), None)
         return a, b, None
@@ -244,31 +406,9 @@ class ExtractionRunner:
         job.current_step = step[:200]
         session.commit()
 
-    # ------------------------------------------------------------------ #
-    # Persistence — one function per field group
-    # ------------------------------------------------------------------ #
-
-    def _persist_field_group(
-        self,
-        session: Session,
-        aerodrome: Aerodrome,
-        field_group: FieldGroup,
-        *,
-        parsed_a: dict,
-        parsed_b: dict,
-    ) -> int:
-        if field_group == "geo":
-            return _persist_geo(aerodrome, parsed_a, parsed_b)
-        if field_group == "runways":
-            return _persist_runways(session, aerodrome, parsed_a, parsed_b)
-        if field_group == "frequencies":
-            return _persist_frequencies(session, aerodrome, parsed_a, parsed_b)
-        # obstacles / reporting_points: no DB tables yet → audit only.
-        return 0
-
 
 # ---------------------------------------------------------------------------
-# Pure helpers (module-level so they're unit-testable without the runner)
+# Pure helpers — per-chart consensus
 # ---------------------------------------------------------------------------
 
 def _has_signal(parsed: Any) -> bool:
@@ -302,54 +442,13 @@ def _agree(a: Any, b: Any, *, float_tol: float = 0.01) -> Any | None:
     sa, sb = str(a).strip(), str(b).strip()
     if sa.lower() == sb.lower():
         return sa
-    # Loose match: drop internal whitespace
     if "".join(sa.split()).lower() == "".join(sb.split()).lower():
         return sa
     return None
 
 
-def _persist_geo(aerodrome: Aerodrome, a: dict, b: dict) -> int:
-    """Update aerodrome columns in-place where both providers agree."""
-    written = 0
-
-    lat = _agree(a.get("latitude_deg"), b.get("latitude_deg"), float_tol=0.001)
-    if lat is not None:
-        aerodrome.latitude = float(lat)
-        written += 1
-
-    lon = _agree(a.get("longitude_deg"), b.get("longitude_deg"), float_tol=0.001)
-    if lon is not None:
-        aerodrome.longitude = float(lon)
-        written += 1
-
-    elev = _agree_int_with_unit(a.get("elevation_ft"), b.get("elevation_ft"))
-    if elev is not None:
-        aerodrome.elevation_ft = elev
-        written += 1
-
-    magvar = _agree(
-        a.get("magnetic_variation_deg"),
-        b.get("magnetic_variation_deg"),
-        float_tol=0.5,
-    )
-    if magvar is not None:
-        try:
-            aerodrome.magnetic_variation = Decimal(str(magvar))
-            written += 1
-        except InvalidOperation:
-            pass
-
-    for field in ("operator", "operator_de", "city", "city_de"):
-        agreed = _agree(a.get(field), b.get(field))
-        if agreed is not None and getattr(aerodrome, field) != agreed:
-            setattr(aerodrome, field, agreed)
-            written += 1
-
-    return written
-
-
 def _agree_int_with_unit(a: Any, b: Any) -> int | None:
-    """Handle elevation-style values like '1487 FT' or '453 M' — strip unit, compare ints."""
+    """Elevation-style values like '1487 FT' or '453 M' — strip unit, compare ints."""
     av = _unwrap(a)
     bv = _unwrap(b)
     if av is None or bv is None:
@@ -358,11 +457,11 @@ def _agree_int_with_unit(a: Any, b: Any) -> int | None:
     bi = _parse_first_int(bv)
     if ai is None or bi is None:
         return None
-    return ai if abs(ai - bi) <= 2 else None  # 2 ft slack for rounding
+    return ai if abs(ai - bi) <= 2 else None
 
 
 def _parse_first_int(s: Any) -> int | None:
-    if isinstance(s, (int,)):
+    if isinstance(s, int):
         return int(s)
     if isinstance(s, float):
         return int(s)
@@ -373,12 +472,107 @@ def _parse_first_int(s: Any) -> int | None:
     return int(m.group()) if m else None
 
 
-def _persist_runways(session: Session, aerodrome: Aerodrome, a: dict, b: dict) -> int:
-    """Replace aerodrome's runway rows with agreed-on entries."""
+def _agreed_geo_on_chart(a: dict, b: dict) -> dict[str, Any]:
+    """Return the dict of scalar fields both providers agreed on for ONE chart."""
+    out: dict[str, Any] = {}
+    lat = _agree(a.get("latitude_deg"), b.get("latitude_deg"), float_tol=0.001)
+    if lat is not None:
+        out["latitude_deg"] = float(lat)
+    lon = _agree(a.get("longitude_deg"), b.get("longitude_deg"), float_tol=0.001)
+    if lon is not None:
+        out["longitude_deg"] = float(lon)
+    elev = _agree_int_with_unit(a.get("elevation_ft"), b.get("elevation_ft"))
+    if elev is not None:
+        out["elevation_ft"] = elev
+    magvar = _agree(
+        a.get("magnetic_variation_deg"), b.get("magnetic_variation_deg"),
+        float_tol=0.5,
+    )
+    if magvar is not None:
+        try:
+            out["magnetic_variation_deg"] = Decimal(str(magvar))
+        except InvalidOperation:
+            pass
+    for field in ("operator", "operator_de", "city", "city_de"):
+        agreed = _agree(a.get(field), b.get(field))
+        if agreed is not None:
+            out[field] = agreed
+    return out
+
+
+_OPPOSITE_SUFFIX = {"L": "R", "R": "L", "C": "C", "": ""}
+
+
+def _opposite_designator(le: str) -> str | None:
+    """Compute the high-end designator from a low-end one.
+
+    Runway designators are always 180° apart: `08L` ↔ `26R`, `07C` ↔ `25C`,
+    `18` ↔ `36`. Returns None if the input doesn't look like a designator.
+    """
+    import re
+    m = re.match(r"^\s*(\d{1,2})\s*([LRC]?)\s*$", str(le).upper())
+    if not m:
+        return None
+    try:
+        n = int(m.group(1))
+    except ValueError:
+        return None
+    if not (1 <= n <= 36):
+        return None
+    opp_num = ((n + 17) % 36) + 1  # 1..36 with 36 wrapping to 18, 18 to 36, etc.
+    suf = _OPPOSITE_SUFFIX.get(m.group(2), "")
+    return f"{opp_num:02d}{suf}"
+
+
+def _resolve_he(rw_a: dict, rw_b: dict, le: str) -> str | None:
+    """Pick the high-end designator, tolerating missing HE from ONE provider.
+
+    Safety rules:
+      1. Both provided HE AND they agree → use the agreed value.
+      2. Both provided HE AND they disagree → reject (don't use LE-math
+         to break the tie; a provider misread).
+      3. Only one provided HE AND it matches the mathematical opposite
+         of LE → accept (runway identity is safe; the other provider
+         simply dropped the field, which we've observed on EDDF).
+      4. Only one provided HE but it doesn't match computed opposite →
+         reject (inconsistent with the agreed LE).
+      5. Neither provided HE → compute from LE.
+
+    Returns None when no safe HE is resolvable.
+    """
+    a_he = _unwrap(rw_a.get("designator_he"))
+    b_he = _unwrap(rw_b.get("designator_he"))
+
+    # Rule 1 & 2 — both sides reported HE.
+    if a_he is not None and b_he is not None:
+        agreed = _agree(
+            {"value": a_he, "bbox": None},
+            {"value": b_he, "bbox": None},
+        )
+        return str(agreed).upper() if agreed else None
+
+    # Rules 3–5 — at least one side dropped HE. Fall back to LE math.
+    computed = _opposite_designator(le)
+    if computed is None:
+        return None
+    provided = a_he if a_he is not None else b_he
+    if provided is not None and str(provided).upper() != computed:
+        return None
+    return computed
+
+
+def _agreed_runways_on_chart(a: dict, b: dict) -> list[dict]:
+    """Return runway dicts both providers agreed on for ONE chart.
+
+    Relaxed rule for `designator_he`: the opposite-end designator is
+    mathematically determined by the low-end (always 180° apart), so if
+    both providers agree on LE we accept the runway and auto-derive HE
+    when providers disagree or one is null. This recovers cases where
+    OpenAI drops the HE (observed on EDDF chart 2 runway 18).
+    """
     rws_a = a.get("runways") or []
     rws_b = b.get("runways") or []
 
-    # Pair up by designator_le — if both providers list a 08L, compare those.
     def keyed(lst):
         out: dict[str, dict] = {}
         for rw in lst:
@@ -390,71 +584,36 @@ def _persist_runways(session: Session, aerodrome: Aerodrome, a: dict, b: dict) -
     keyed_a = keyed(rws_a)
     keyed_b = keyed(rws_b)
 
-    agreed_rows = []
+    agreed: list[dict] = []
     for le, rw_a in keyed_a.items():
         rw_b = keyed_b.get(le)
         if rw_b is None:
             continue
         le_agreed = _agree(rw_a.get("designator_le"), rw_b.get("designator_le"))
-        he_agreed = _agree(rw_a.get("designator_he"), rw_b.get("designator_he"))
-        if not le_agreed or not he_agreed:
+        if not le_agreed:
+            continue
+        he_agreed = _resolve_he(rw_a, rw_b, str(le_agreed).upper())
+        if not he_agreed:
             continue
         length_m = _agree_int_with_unit(rw_a.get("length_m"), rw_b.get("length_m"))
         width_m = _agree_int_with_unit(rw_a.get("width_m"), rw_b.get("width_m"))
         surface_raw = _agree(rw_a.get("surface"), rw_b.get("surface"))
         surface = _map_surface(surface_raw) if surface_raw else RunwaySurface.OTHER
-        agreed_rows.append({
+        agreed.append({
             "designator_le": str(le_agreed).upper(),
-            "designator_he": str(he_agreed).upper(),
+            "designator_he": he_agreed,
             "length_m": length_m,
             "width_m": width_m,
             "surface": surface,
         })
-
-    if not agreed_rows:
-        return 0
-
-    session.execute(
-        delete(Runway).where(Runway.aerodrome_icao == aerodrome.icao)
-    )
-    session.flush()
-
-    airac = aerodrome.source_airac_cycle
-    for row in agreed_rows:
-        session.add(Runway(
-            aerodrome_icao=aerodrome.icao,
-            source_airac_cycle=airac,
-            **row,
-        ))
-    return len(agreed_rows)
+    return agreed
 
 
-def _map_surface(raw: str | None) -> RunwaySurface:
-    if not raw:
-        return RunwaySurface.OTHER
-    token = str(raw).strip().lower()
-    # Direct enum match
-    for surf in RunwaySurface:
-        if surf.value == token:
-            return surf
-    # Best-effort mapping for compound / German terms
-    if "asph" in token or "bitum" in token:
-        return RunwaySurface.ASPHALT
-    if "beton" in token or "conc" in token:
-        return RunwaySurface.CONCRETE
-    if "gras" in token or "grass" in token:
-        return RunwaySurface.GRASS
-    if "gravel" in token or "schotter" in token:
-        return RunwaySurface.GRAVEL
-    return RunwaySurface.OTHER
-
-
-def _persist_frequencies(session: Session, aerodrome: Aerodrome, a: dict, b: dict) -> int:
-    """Replace aerodrome's frequency rows with agreed-on entries."""
+def _agreed_frequencies_on_chart(a: dict, b: dict) -> list[dict]:
+    """Return frequency dicts both providers agreed on for ONE chart."""
     a_list = a.get("frequencies") or []
     b_list = b.get("frequencies") or []
 
-    # Pair by (type, frequency_mhz) — the canonical identity of a freq row.
     def keyed(lst):
         out: dict[tuple[str, str], dict] = {}
         for item in lst:
@@ -490,23 +649,91 @@ def _persist_frequencies(session: Session, aerodrome: Aerodrome, a: dict, b: dic
             "callsign_de": callsign_de,
             "operational_hours": hours,
         })
+    return agreed
 
-    if not agreed:
+
+# ---------------------------------------------------------------------------
+# DB writes — take aggregated results, replace target tables
+# ---------------------------------------------------------------------------
+
+def _apply_geo_dict(aerodrome: Aerodrome, geo: dict[str, Any]) -> int:
+    """Apply the merged geo dict to the aerodrome row. Returns fields changed."""
+    written = 0
+    mapping = {
+        "latitude_deg": ("latitude", float),
+        "longitude_deg": ("longitude", float),
+        "elevation_ft": ("elevation_ft", int),
+        "magnetic_variation_deg": ("magnetic_variation", None),  # Decimal already
+        "operator": ("operator", str),
+        "operator_de": ("operator_de", str),
+        "city": ("city", str),
+        "city_de": ("city_de", str),
+    }
+    for src, (attr, caster) in mapping.items():
+        if src not in geo:
+            continue
+        value = geo[src]
+        if caster and not isinstance(value, caster):
+            try:
+                value = caster(value)
+            except (TypeError, ValueError):
+                continue
+        if getattr(aerodrome, attr) != value:
+            setattr(aerodrome, attr, value)
+            written += 1
+    return written
+
+
+def _write_runways(session: Session, aerodrome: Aerodrome, rows: list[dict]) -> int:
+    if not rows:
         return 0
-
-    session.execute(
-        delete(Frequency).where(Frequency.aerodrome_icao == aerodrome.icao)
-    )
+    session.execute(delete(Runway).where(Runway.aerodrome_icao == aerodrome.icao))
     session.flush()
-
     airac = aerodrome.source_airac_cycle
-    for row in agreed:
+    for row in rows:
+        session.add(Runway(
+            aerodrome_icao=aerodrome.icao,
+            source_airac_cycle=airac,
+            **row,
+        ))
+    return len(rows)
+
+
+def _write_frequencies(session: Session, aerodrome: Aerodrome, rows: list[dict]) -> int:
+    if not rows:
+        return 0
+    session.execute(delete(Frequency).where(Frequency.aerodrome_icao == aerodrome.icao))
+    session.flush()
+    airac = aerodrome.source_airac_cycle
+    for row in rows:
         session.add(Frequency(
             aerodrome_icao=aerodrome.icao,
             source_airac_cycle=airac,
             **row,
         ))
-    return len(agreed)
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Enum mappers (unchanged from #35)
+# ---------------------------------------------------------------------------
+
+def _map_surface(raw: str | None) -> RunwaySurface:
+    if not raw:
+        return RunwaySurface.OTHER
+    token = str(raw).strip().lower()
+    for surf in RunwaySurface:
+        if surf.value == token:
+            return surf
+    if "asph" in token or "bitum" in token:
+        return RunwaySurface.ASPHALT
+    if "beton" in token or "conc" in token:
+        return RunwaySurface.CONCRETE
+    if "gras" in token or "grass" in token:
+        return RunwaySurface.GRASS
+    if "gravel" in token or "schotter" in token:
+        return RunwaySurface.GRAVEL
+    return RunwaySurface.OTHER
 
 
 def _map_freq_type(token: str) -> FrequencyType | None:
@@ -514,7 +741,6 @@ def _map_freq_type(token: str) -> FrequencyType | None:
     for ft in FrequencyType:
         if ft.value == token:
             return ft
-    # Fallbacks for prompt-output variants
     alias = {
         "tower": FrequencyType.TWR,
         "ground": FrequencyType.GND,

--- a/services/data-ingestion/tests/test_extraction_runner_aggregators.py
+++ b/services/data-ingestion/tests/test_extraction_runner_aggregators.py
@@ -1,0 +1,284 @@
+"""Tests for the multi-chart aggregator helpers in ExtractionRunner (#36).
+
+The per-chart aggregator functions are pure — given two parsed provider
+responses for ONE chart, they return the consensus entries. The runner
+glues these together across multiple charts.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from shared.schemas.enums import FrequencyType, RunwaySurface
+
+from app.services.extraction_runner import (
+    _agreed_frequencies_on_chart,
+    _agreed_geo_on_chart,
+    _agreed_runways_on_chart,
+)
+
+
+def _ev(value, bbox=(0, 0, 1, 1)):
+    """Build an ExtractedValue-shaped dict {value, bbox}."""
+    return {"value": value, "bbox": list(bbox)}
+
+
+# ---------------------------------------------------------------------------
+# _agreed_geo_on_chart — returns only fields both providers matched
+# ---------------------------------------------------------------------------
+
+def test_geo_returns_agreed_fields_only():
+    a = {
+        "latitude_deg": _ev(48.3536),
+        "longitude_deg": _ev(11.7858),
+        "elevation_ft": _ev("1487 FT"),
+        "city": _ev("Munich"),
+        "operator": None,
+    }
+    b = {
+        "latitude_deg": _ev(48.3538),   # within 0.001 float-tol
+        "longitude_deg": _ev(11.7855),
+        "elevation_ft": _ev(1487),
+        "city": _ev("Munich"),
+        "operator": _ev("Flughafen München"),  # only one side — excluded
+    }
+    out = _agreed_geo_on_chart(a, b)
+    assert out["elevation_ft"] == 1487
+    assert out["city"] == "Munich"
+    assert "operator" not in out
+    assert abs(out["latitude_deg"] - 48.3536) < 0.001
+
+
+def test_geo_empty_when_nothing_agrees():
+    a = {"city": _ev("Munich")}
+    b = {"city": _ev("Berlin")}
+    assert _agreed_geo_on_chart(a, b) == {}
+
+
+def test_geo_handles_all_null_input():
+    assert _agreed_geo_on_chart({}, {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _agreed_runways_on_chart
+# ---------------------------------------------------------------------------
+
+def test_runways_both_providers_report_same_rwy():
+    a = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26R"),
+        "length_m": _ev(4000),
+        "width_m": _ev(60),
+        "surface": _ev("asphalt"),
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26R"),
+        "length_m": _ev("4000 m"),
+        "width_m": _ev("60 m"),
+        "surface": _ev("ASPHALT"),
+    }]}
+    out = _agreed_runways_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["designator_le"] == "08L"
+    assert out[0]["designator_he"] == "26R"
+    assert out[0]["length_m"] == 4000
+    assert out[0]["surface"] is RunwaySurface.ASPHALT
+
+
+def test_runways_disagreeing_designators_dropped():
+    a = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26R"),
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26L"),  # disagrees
+    }]}
+    assert _agreed_runways_on_chart(a, b) == []
+
+
+def test_runways_only_in_one_provider_dropped():
+    a = {"runways": [
+        {"designator_le": _ev("08L"), "designator_he": _ev("26R")},
+        {"designator_le": _ev("18"), "designator_he": _ev("36")},  # only in A
+    ]}
+    b = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26R"),
+    }]}
+    out = _agreed_runways_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["designator_le"] == "08L"
+
+
+def test_runways_missing_dims_still_included():
+    """If providers agree on the runway identity, we accept it even if length
+    / width / surface are null — the runway row itself is the 2-of-2 fact."""
+    a = {"runways": [{
+        "designator_le": _ev("07"),
+        "designator_he": _ev("25"),
+        "length_m": None,
+        "width_m": None,
+        "surface": None,
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("07"),
+        "designator_he": _ev("25"),
+        "length_m": None,
+        "width_m": None,
+        "surface": None,
+    }]}
+    out = _agreed_runways_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["length_m"] is None
+    assert out[0]["surface"] is RunwaySurface.OTHER  # default
+
+
+def test_runways_empty_lists_return_empty():
+    assert _agreed_runways_on_chart({"runways": []}, {"runways": []}) == []
+    assert _agreed_runways_on_chart({}, {}) == []
+
+
+# HE-autofill (observed on EDDF chart 2: OpenAI drops designator_he for runway 18).
+# Runway designators are always 180° apart so LE alone determines HE
+# mathematically. We tolerate ONE provider dropping HE, not both
+# disagreeing.
+
+def test_runways_autofill_he_when_one_provider_drops_it():
+    a = {"runways": [{
+        "designator_le": _ev("18"),
+        "designator_he": _ev("36"),
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("18"),
+        "designator_he": None,   # OpenAI dropped it
+    }]}
+    out = _agreed_runways_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["designator_le"] == "18"
+    assert out[0]["designator_he"] == "36"
+
+
+def test_runways_autofill_he_when_both_providers_drop_it():
+    a = {"runways": [{
+        "designator_le": _ev("07L"),
+        "designator_he": None,
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("07L"),
+        "designator_he": None,
+    }]}
+    out = _agreed_runways_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["designator_le"] == "07L"
+    assert out[0]["designator_he"] == "25R"  # 07L + 180° = 25R
+
+
+def test_runways_reject_when_lone_he_disagrees_with_math():
+    """One provider gave HE=29 for LE=07 — that's wrong and we won't pretend to agree."""
+    a = {"runways": [{
+        "designator_le": _ev("07"),
+        "designator_he": _ev("29"),  # nonsense
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("07"),
+        "designator_he": None,
+    }]}
+    assert _agreed_runways_on_chart(a, b) == []
+
+
+def test_runways_reject_when_both_provided_but_disagree():
+    """Disagreement between providers on HE is never tie-broken by math."""
+    a = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26R"),
+    }]}
+    b = {"runways": [{
+        "designator_le": _ev("08L"),
+        "designator_he": _ev("26L"),   # wrong
+    }]}
+    assert _agreed_runways_on_chart(a, b) == []
+
+
+def test_runways_autofill_preserves_suffix_opposite():
+    """07C ↔ 25C, 08L ↔ 26R, 08R ↔ 26L."""
+    for le, expected_he in [("07C", "25C"), ("08L", "26R"), ("08R", "26L")]:
+        a = {"runways": [{"designator_le": _ev(le), "designator_he": None}]}
+        b = {"runways": [{"designator_le": _ev(le), "designator_he": None}]}
+        out = _agreed_runways_on_chart(a, b)
+        assert len(out) == 1, f"LE={le}"
+        assert out[0]["designator_he"] == expected_he, f"LE={le} expected {expected_he}"
+
+
+# ---------------------------------------------------------------------------
+# _agreed_frequencies_on_chart
+# ---------------------------------------------------------------------------
+
+def test_frequencies_matched_by_type_and_value():
+    a = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700"),
+         "callsign": _ev("Munich Tower"), "callsign_de": _ev("München Turm"),
+         "operational_hours": _ev("H24")},
+    ]}
+    b = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700"),
+         "callsign": _ev("Munich Tower"), "callsign_de": None,
+         "operational_hours": _ev("H24")},
+    ]}
+    out = _agreed_frequencies_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["type"] is FrequencyType.TWR
+    assert out[0]["frequency_mhz"] == Decimal("118.700")
+    assert out[0]["callsign"] == "Munich Tower"
+    assert out[0]["callsign_de"] is None  # only in A
+    assert out[0]["operational_hours"] == "H24"
+
+
+def test_frequencies_disagreeing_freq_dropped():
+    a = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700")},
+    ]}
+    b = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.705")},  # differs
+    ]}
+    assert _agreed_frequencies_on_chart(a, b) == []
+
+
+def test_frequencies_unknown_type_dropped():
+    a = {"frequencies": [
+        {"type": _ev("xyz"), "frequency_mhz": _ev("118.700")},
+    ]}
+    b = {"frequencies": [
+        {"type": _ev("xyz"), "frequency_mhz": _ev("118.700")},
+    ]}
+    assert _agreed_frequencies_on_chart(a, b) == []
+
+
+def test_frequencies_case_insensitive_type_match():
+    a = {"frequencies": [
+        {"type": _ev("TWR"), "frequency_mhz": _ev("118.700")},
+    ]}
+    b = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700")},
+    ]}
+    out = _agreed_frequencies_on_chart(a, b)
+    assert len(out) == 1
+    assert out[0]["type"] is FrequencyType.TWR
+
+
+def test_frequencies_multiple_entries_preserved_by_key():
+    a = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700")},
+        {"type": _ev("atis"), "frequency_mhz": _ev("123.125")},
+        {"type": _ev("gnd"), "frequency_mhz": _ev("121.975")},
+    ]}
+    b = {"frequencies": [
+        {"type": _ev("twr"), "frequency_mhz": _ev("118.700")},
+        {"type": _ev("atis"), "frequency_mhz": _ev("123.125")},
+        {"type": _ev("gnd"), "frequency_mhz": _ev("121.975")},
+    ]}
+    out = _agreed_frequencies_on_chart(a, b)
+    assert len(out) == 3
+    types = {e["type"] for e in out}
+    assert types == {FrequencyType.TWR, FrequencyType.ATIS, FrequencyType.GND}


### PR DESCRIPTION
Closes #36.

## Summary

Extraction runner now iterates ALL acceptable candidates per field group and merges results across charts — not just the first-with-signal pick from #35. Plus three consensus-unblocking fixes discovered by running a live diagnostic against EDDF.

## Validated end-to-end on EDDF

| | Before | After |
|---|---|---|
| Runways | 2 (07C/25C, 07R/25L) | **3** (+ 18/36 via HE-autofill) |
| Frequencies | 0 | **7** (TWR×3, GND, ATIS, FIS×2) |
| Fields written total | 2 | **10** |

Runway 07L/25R is still missing because OpenAI can't read chart 3 (returns empty) even though Claude sees it. Not a code issue — prompt work, separate follow-up.

## What changed

**1. Multi-chart aggregation** — `ExtractionRunner._run_pipeline` now iterates every acceptable candidate (capped at 10). Per chart: 2-of-2 consensus entries are computed. Across charts: unique entries merged by natural key (`designator_le`, `(type, freq_mhz)`). Scalar `geo` fills gaps: keep earlier non-null values, only overwrite nothing.

**2. Image-guard byte-budget ladder** — Anthropic has TWO independent limits: pixel dimensions AND base64 body ≤ 5 MB. A 2048-px PNG at full quality can still exceed 5 MB for high-detail aerodrome charts. `downscale_png` now walks a ladder `2048 → 1568 → 1280 → 1024 → 768` until the re-encoded PNG fits a 3.6 MB raw budget (≈4.8 MB base64). Fixed: EDDF chart 1 + Terminal Chart were failing on retry too.

**3. HE-autofill** — runway designators are always 180° apart so LE alone determines HE (`18↔36`, `07C↔25C`, `08L↔26R`). If providers agree on LE but ONE side dropped HE, `_resolve_he` auto-fills from LE. If both sides provided HE and disagree → reject (safety preserved). Fixed: 18/36 on EDDF chart 2 which OpenAI reported without HE.

**4. Robust OpenAI JSON parser** — `openai_vision._extract_json` mirrors the claude_vision helper: strips markdown fences, falls back to `{...}` block extraction on `JSONDecodeError`. Fixed: EDDF chart 3 was crashing OpenAI.

**5. Provider-fault logging** — `log.exception` in `_call_both_providers` so docker logs show root cause even when the audit row only keeps 400 chars.

## Test plan

- [x] 13 new aggregator tests — incl. 5 dedicated HE-autofill cases (both-provided-agree, both-dropped, one-dropped, lone-wrong-HE-rejected, suffix-opposite preserved).
- [x] Existing 20 image_guard tests still pass with the ladder.
- [x] Full suite: **210 passed**.
- [x] Live-validated on EDDF: 3 runways + 7 frequencies persisted.

## Out of scope (follow-ups)

- Prompt work to get OpenAI to see EDDF chart 3 runways.
- Obstacles + reporting_points DB tables.
- Elevation extraction quality on EDDF (requires prompt or different chart).
- TWR callsign agreement (providers phrase it differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)