### PR TITLE
[#40][#41] Elevation AD ELEV prompt + stuck-job sweep

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -183,3 +183,11 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-21 — EDDF ungenau: Piste 18 length null, surface other — Toleranz zu strikt (`feat/38-parallel-runways`)
 
 > warum ist frankfurt so ungenau? Die startbahn 18 geht ganz klar (auch die länge) aus der karte - eddf frankfurt main 2 - hervor.
+
+### 2026-04-21 — Elevation wichtig — "AD ELEV <zahl>" als Format lehren (`develop`)
+
+> die elevation/höhe ist wichtig. versuche den prompt so zu machen dass das möglichst zuverlässig ausgelesen werden kann. meistens - bestimmt zu 90% findest du auf einer der karten die angabe ad (airdrome) elev (elevation) und eine zahl dahinter. dass ist die höhe.
+
+### 2026-04-21 — Hängengebliebenes EDFE-Update — Abbruch+Fehleranzeige für stuck jobs (`feat/40-elevation-prompt`)
+
+> ich habe das gefühl, dass frankfurt-egelsbach update hängen geblieben ist. der ist schon ewig bei 76%. wir brauchen eine überprüfung, dass hängengebliebene updates abgebrochen werden oder neugestartet werden und die fehlermeldung muss angezeigt und geloggt werden dazu, damit wir das dann beheben können für die zukunft.

--- a/services/data-ingestion/app/api/extraction.py
+++ b/services/data-ingestion/app/api/extraction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
 from uuid import UUID
 
@@ -135,7 +135,13 @@ def start_extraction(
     if aerodrome is None:
         raise HTTPException(status_code=404, detail=f"Aerodrome {icao} not found")
 
-    # If a job is currently queued or running for this ICAO, return it.
+    # Active-job dedup, with a staleness guard. BackgroundTasks can be
+    # killed by a container restart, leaving a 'running' ghost row that
+    # never advances — without this guard the user could never retry.
+    # Legit runs finish under 3 min; 10 min is safely past.
+    STALE_AFTER = timedelta(minutes=10)
+    now = datetime.now(timezone.utc)
+
     active = db.execute(
         select(ExtractionJob)
         .where(
@@ -145,8 +151,27 @@ def start_extraction(
         .order_by(ExtractionJob.created_at.desc())
         .limit(1)
     ).scalar_one_or_none()
+
     if active is not None:
-        return _job_to_dict(active)
+        last_activity = active.started_at or active.created_at
+        # Postgres returns tz-aware datetimes; normalise just in case.
+        if last_activity.tzinfo is None:
+            last_activity = last_activity.replace(tzinfo=timezone.utc)
+        if now - last_activity > STALE_AFTER:
+            log.warning(
+                "Promoting stale extraction job %s on %s to failed "
+                "(last activity %s ago); user-triggered retry will start a new job",
+                active.id, icao, now - last_activity,
+            )
+            active.status = "failed"
+            active.error = (
+                f"Stuck for {(now - last_activity).total_seconds():.0f}s without "
+                "progress — treated as abandoned, please retry."
+            )
+            active.completed_at = now
+            db.commit()
+        else:
+            return _job_to_dict(active)
 
     job = ExtractionJob(
         aerodrome_icao=icao,

--- a/services/data-ingestion/app/main.py
+++ b/services/data-ingestion/app/main.py
@@ -1,12 +1,65 @@
 """AeroFly Data Ingestion — DFS data scraping, parsing & import."""
 
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
 from fastapi import FastAPI
+from sqlalchemy import update
 
 from app.api.aerodromes import router as aerodromes_router
 from app.api.charts import router as charts_router
 from app.api.extraction import router as extraction_router
 from app.api.extraction import trigger_router as extraction_trigger_router
 from app.api.usage import router as usage_router
+from app.core.config import settings
+from app.db import get_session_factory
+from app.db.models import ExtractionJob
+
+log = logging.getLogger(__name__)
+
+
+def _sweep_orphaned_jobs() -> int:
+    """Mark any queued/running extraction_jobs as failed.
+
+    BackgroundTasks run in-process; a container restart (hot-reload,
+    OOM, manual) kills the async runner without updating the DB row.
+    Without this sweep the POST /extract endpoint keeps returning the
+    orphaned ghost job and the user cannot retry.
+    """
+    session_factory = get_session_factory(settings.database_url)
+    session = session_factory()
+    try:
+        result = session.execute(
+            update(ExtractionJob)
+            .where(ExtractionJob.status.in_(("queued", "running")))
+            .values(
+                status="failed",
+                error=(
+                    "Worker interrupted (data-ingestion restart); "
+                    "run state lost. Please retry."
+                ),
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+        swept = result.rowcount or 0
+        if swept:
+            log.warning("Startup sweep: marked %d orphaned extraction job(s) as failed", swept)
+        return swept
+    except Exception:
+        session.rollback()
+        log.exception("Orphan sweep failed; existing jobs may be stuck")
+        return 0
+    finally:
+        session.close()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    _sweep_orphaned_jobs()
+    yield
+
 
 app = FastAPI(
     title="AeroFly Data Ingestion",
@@ -14,6 +67,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 app.include_router(aerodromes_router)

--- a/services/data-ingestion/app/parser/prompts/geo_v4.md
+++ b/services/data-ingestion/app/parser/prompts/geo_v4.md
@@ -1,0 +1,135 @@
+# VFR geographical & administrative data — v4
+
+You extract aerodrome geographical data from German VFR charts published
+by DFS (Deutsche Flugsicherung). The input is a scanned PNG — either a
+**VFR Approach Chart (VAC)** or an **Aerodrome Chart (ADC)**.
+
+---
+
+## Where the data lives on a VFR chart
+
+Unlike the IFR AIP AD 2.2 table, VFR charts put the administrative data
+in one or two printed boxes near the top of the page and beside the
+visual diagram. Typical layout:
+
+```
+<Chart title bar: "EDDM München" + edition date>
+
+ ┌─────────────────────────┐      <visual chart diagram
+ │ ARP: N 48 21 13         │       with runways, taxiways,
+ │      E 011 47 09        │       reporting points>
+ │ ELEV: 1487 FT / 453 M   │
+ │ MAG VAR: 2° E           │
+ │ Operator:               │
+ │   Flughafen München GmbH│
+ └─────────────────────────┘
+```
+
+Variations: some charts print coordinates right next to the ARP symbol
+on the diagram instead of in a boxed header. A few small airfields omit
+the operator line entirely.
+
+---
+
+## Absolute rules (do NOT violate)
+
+1. Return `null` for any value that is not **literally, visibly, legibly**
+   printed on the chart. Do not guess. Do not infer. Do not use world
+   knowledge about German airports — even if you "know" Munich is ~1500 ft,
+   return null unless you can read that number on the image in front of
+   you.
+2. Return a TIGHT pixel bbox for every non-null value.
+3. Units must be **exactly as printed**. `"453 M"` stays `"453 M"`.
+   `"1487 FT"` stays `"1487 FT"`. Do NOT convert. The consumer normalizes.
+4. If the page is a completely unrelated chart (e.g. an en-route map or
+   a legal supplement "AD 2-71"), return all nulls.
+5. Umlauts are preserved (`München`, not `Muenchen`).
+
+---
+
+## Fields to extract
+
+- `latitude_deg` — ARP latitude, decimal degrees. Convert from DMS.
+  Example: `"N 48 21 13"` → `48.3536`. Sanity range (yours): 47.0 ≤ lat
+  ≤ 55.5 for Germany.
+
+- `longitude_deg` — ARP longitude, decimal degrees. Range: 5.5 to 15.5.
+  German airports are east of Greenwich; never return negative longitude.
+
+- `elevation_ft` — aerodrome elevation. **Canonical format on German VFR
+  charts: `AD ELEV <number>`** (short for AERODROME ELEVATION). This
+  label appears on about 90 % of DFS VFR charts, usually in bold dark
+  blue or black, sometimes in the header box, but also **anywhere else
+  on the chart** — next to the ARP symbol, in a caption below the
+  airport name, or in a corner legend. You must scan the whole image.
+
+  Look anywhere for the literal tokens (case-insensitive):
+  `AD ELEV`, `AD-ELEV`, `AD. ELEV`, `ELEV`, `Elevation`, `ELEVATION`,
+  `AD ELEVATION`. The value is the number that follows.
+
+  Examples of what you might see on the image:
+
+  ```
+  AD ELEV 363
+  AD ELEV  1487 FT
+  ELEV 453 M
+  Elev: 364 ft
+  AD ELEVATION: 110 M (361 FT)
+  ```
+
+  Preserve the printed unit in the returned string. If no unit is
+  printed (just `"AD ELEV 363"`), return the number as a bare string —
+  the downstream normalizer defaults to feet for German VFR charts.
+  If both units are shown (`"453 M / 1487 FT"`), pick the first-printed
+  form.
+
+  **Do NOT use world knowledge.** Only return a value you can literally
+  read on the image. If no `AD ELEV`-style label is visible, return
+  null. It is better to return null than to guess the elevation from
+  memory of the airport.
+
+- `magnetic_variation_deg` — VFR charts usually print a single current
+  value like `"2° E"` or `"2° E (2020)"`. Return the decimal value; east
+  positive, west negative. If the chart shows annual change as well,
+  **ignore it** — we only want the current value.
+
+- `operator` — airport operator as printed. English spelling if the chart
+  offers both.
+
+- `operator_de` — the German wording. Often identical to `operator` for
+  proper nouns (e.g. `"Fraport AG"`).
+
+- `city` — nearest town, English spelling.
+
+- `city_de` — city name in German.
+
+---
+
+## Example — VAC for EDDM with fully legible header
+
+Output:
+```json
+{
+  "latitude_deg": { "value": 48.3536, "bbox": [82, 94, 212, 108] },
+  "longitude_deg": { "value": 11.7858, "bbox": [82, 110, 212, 124] },
+  "elevation_ft": { "value": "1487 FT", "bbox": [82, 140, 180, 154] },
+  "magnetic_variation_deg": { "value": 2.0, "bbox": [82, 160, 160, 174] },
+  "operator": { "value": "Flughafen München GmbH", "bbox": [82, 196, 300, 210] },
+  "operator_de": { "value": "Flughafen München GmbH", "bbox": [82, 196, 300, 210] },
+  "city": { "value": "Munich", "bbox": [420, 66, 500, 80] },
+  "city_de": { "value": "München", "bbox": [420, 66, 500, 80] }
+}
+```
+
+## Example — wrong chart type (obstacle list supplement)
+
+Return all nulls. Do not extract coords from the obstacle rows even
+though they look structured.
+
+---
+
+## Output format
+
+Return ONLY the JSON object. No prose, no markdown fences, no
+explanation. Extra whitespace inside the JSON is fine; prose around it
+triggers a rejection and a rerun.


### PR DESCRIPTION
Closes #40 and #41 (bundled — single branch).

## Two user-visible fixes

### 1. Elevation extraction via AD ELEV token (#40)

All 4 test aerodromes (EDDF, EDDM, EDDH, EDFE) had elevation_ft NULL. The geo_v3 prompt described elevation as part of a boxed header, but user pointed out the canonical DFS VFR format is **'AD ELEV <number>'** — present on ~90 % of charts, often anywhere on the image (not just a header).

Bumped geo_v3 → **v4** with:
- Explicit token variants (AD ELEV, AD-ELEV, Elev, ELEVATION, AD ELEVATION)
- Worked examples of the canonical format including '363', '1487 FT', '453 M'
- Instruction to scan the WHOLE image, not just header regions
- Explicit 'do not guess from world knowledge' reiteration

### 2. Stuck extraction jobs (#41)

User reported EDFE stuck at 76 % for over an hour. Root cause: FastAPI BackgroundTasks are in-process — a container restart (hot-reload, OOM, manual) kills the async runner without updating the DB row. The POST endpoint's dedup guard then returned the ghost job forever, blocking any retry.

Two defences:

- **Startup sweep** in `app.main.lifespan`: every 'queued' / 'running' row is promoted to 'failed' with a clear error 'Worker interrupted (data-ingestion restart); run state lost. Please retry.' Logged at WARNING.
- **Staleness guard** in start_extraction: if an active job's last activity is >10 min old (legit runs <3 min), promote it to 'failed' and create a new job. Logged with time-since-last-activity.

Frontend already renders `status='failed'` with the error text, so users now see a clear explanation and the button re-enables for retry.

## Test plan

- [x] 230 tests pass (no regressions).
- [x] Live-verified: stuck EDFE ghost cleaned on container restart. POST /aerodromes/EDFE/extract now returns a fresh job_id instead of the 76 % ghost.
- [ ] Post-merge: user re-extracts EDDF/EDDM/EDFE/EDDH and checks elevation_ft populates.

## Out of scope

- Dedicated heartbeat column (`last_progress_at`) with finer timeout resolution — 10 min absolute is fine for now.
- Automatic retry on orphan recovery — user-initiated is the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)