### PR TITLE
[#44] Chart viewer rotation (90° steps, persisted per chart)

### DIFF
--- a/docs/BUG_REGISTRY.md
+++ b/docs/BUG_REGISTRY.md
@@ -43,3 +43,10 @@ Each entry:
 - **Fix**: One-off backfill — iterate `data/aerodromes/*/manifest.json`, apply `classify_chart_type()` + `extract_chart_suffix()` to each document missing the fields, write back. Ran against 433 manifests / 1363 documents. Fresh scrapes already produce tagged manifests.
 - **Affected files**: `data/aerodromes/*/manifest.json`.
 - **Commit/PR**: discovered during #32 spike validation.
+
+### [BUG-005] Chart viewer modal collapses + flickers after rotation
+- **Symptom**: After clicking a rotation button in the chart viewer, the modal body shrinks to a thin horizontal strip (~200 px tall) and the viewer flickers open/closed rapidly, making the UI unusable.
+- **Root cause**: Two compounding issues. (1) An inner `<div class="chart-viewer-rotation-host">` wrapper was added inside `react-zoom-pan-pinch`'s `TransformComponent`. RZPP measures its content's intrinsic size to compute fit; the percentage-sized wrapper had no intrinsic size of its own, so RZPP collapsed the stage to ~0 height. (2) A `ResizeObserver` was attached to that same wrapper to drive the rotated image's `max-width`/`max-height`. Updating those styles changed the wrapper's box, the observer fired again, and so on — a classic feedback loop.
+- **Fix**: Remove the inner wrapper, render `<img>` directly inside `TransformComponent` (pre-rotation layout). Replace `ResizeObserver` with a one-shot `useLayoutEffect` keyed on `rotation` plus a `window` resize listener; re-measure only when the user actually rotates or resizes the viewport.
+- **Affected files**: `services/frontend/src/components/ChartViewer.tsx`, `services/frontend/src/styles/global.css`
+- **Commit/PR**: #44 (caught during initial UI test on EDDK Koeln Bonn 3 — fixed before merge).

--- a/docs/Design-Kits/aerofly-design-kit.html
+++ b/docs/Design-Kits/aerofly-design-kit.html
@@ -1280,6 +1280,7 @@
         <li><a href="#sec-20">20. Mockup: Search</a></li>
         <li><a href="#sec-21">21. Mockup: Aerodrome Detail</a></li>
         <li><a href="#sec-22">22. Mockup: Dashboard</a></li>
+        <li><a href="#sec-23">23. Chart Viewer Toolbar (Rotation)</a></li>
       </ul>
     </aside>
 
@@ -2598,6 +2599,42 @@
             </div>
           </div>
         </div>
+      </section>
+
+      <!-- ================================================================ -->
+      <!-- 23. Chart Viewer Toolbar (Rotation)                               -->
+      <!-- ================================================================ -->
+      <section class="kit-section" id="sec-23">
+        <h2><span class="sec-num">23</span>Chart Viewer Toolbar (Rotation)</h2>
+        <p class="sec-desc">
+          Toolbar im Großansicht-Viewer. Kombiniert Zoom-Controls (links) und Rotations-Controls (rechts) als ein zusammenhängendes
+          Glassmorphism-Cluster. Rotation ist pro Chart in der DB persistiert (<code>ingest.charts.rotation_degrees</code>, 0/90/180/270).
+          Reset-Rotation setzt auf 0° und schreibt 0 in die DB. Die <code>data-rotation</code>-Attribute zeigen den aktuell gespeicherten Wert.
+        </p>
+        <div class="kit-preview block">
+          <div class="chart-viewer-controls" style="position: static; display: inline-flex; gap: var(--space-1); padding: var(--space-2); border-radius: var(--radius-md); background: var(--color-surface-elev); border: 1px solid var(--color-border);">
+            <button type="button" class="icon-button" aria-label="Zoom in"><i class="fa-solid fa-plus"></i></button>
+            <button type="button" class="icon-button" aria-label="Zoom out"><i class="fa-solid fa-minus"></i></button>
+            <button type="button" class="icon-button" aria-label="Reset zoom"><i class="fa-solid fa-magnifying-glass"></i></button>
+            <span style="width:1px;background:var(--color-border);margin:var(--space-1) var(--space-1);" aria-hidden="true"></span>
+            <button type="button" class="icon-button" aria-label="Rotate 90° left" data-rotation="action-left"><i class="fa-solid fa-rotate-left"></i></button>
+            <button type="button" class="icon-button" aria-label="Rotate 90° right" data-rotation="action-right"><i class="fa-solid fa-rotate-right"></i></button>
+            <button type="button" class="icon-button" aria-label="Reset rotation" data-rotation="action-reset"><i class="fa-solid fa-arrows-up-down-left-right"></i></button>
+          </div>
+        </div>
+        <p class="sec-desc" style="margin-top:var(--space-3);">
+          <strong>Verhalten:</strong>
+        </p>
+        <ul style="font-size:var(--fs-sm); color:var(--color-text-muted); margin-top:0;">
+          <li>Klick auf <code>Rotate left</code> / <code>Rotate right</code> → Karte dreht 90° in die jeweilige Richtung. Persistierung erfolgt sofort via PATCH.</li>
+          <li>Klick auf <code>Reset rotation</code> → Karte auf 0° zurücksetzen, DB-Wert auf 0 setzen.</li>
+          <li>Beim Öffnen einer Karte wird der gespeicherte <code>rotation_degrees</code>-Wert automatisch angewandt.</li>
+          <li>Pan und Zoom bleiben nach Rotation funktionsfähig; Fit-to-Screen wird neu berechnet (Container-<code>width</code>↔<code>height</code> tauschen bei 90°/270°).</li>
+          <li>Trennlinie zwischen Zoom- und Rotations-Block visuell und semantisch (Gruppe).</li>
+        </ul>
+        <p class="sec-desc" style="margin-top:var(--space-3);">
+          <strong>Out of scope dieser Toolbar:</strong> Pinch-Rotate-Geste, Hotkeys, freie (nicht-90°) Rotation, Auto-Orientation-Hint — alles als Folge-Issues.
+        </p>
       </section>
 
       <footer style="margin-top:var(--space-16); padding-top:var(--space-8); border-top:1px solid var(--color-border-strong); color:var(--color-text-muted); font-size:var(--fs-sm);">

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -191,3 +191,35 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-21 — Hängengebliebenes EDFE-Update — Abbruch+Fehleranzeige für stuck jobs (`feat/40-elevation-prompt`)
 
 > ich habe das gefühl, dass frankfurt-egelsbach update hängen geblieben ist. der ist schon ewig bei 76%. wir brauchen eine überprüfung, dass hängengebliebene updates abgebrochen werden oder neugestartet werden und die fehlermeldung muss angezeigt und geloggt werden dazu, damit wir das dann beheben können für die zukunft.
+
+### 2026-04-26 — Was steht als nächstes auf der Liste? (`develop`)
+
+> was hast du als nächstes auf der liste als task?
+
+### 2026-04-26 — Karten im großen Viewer drehen können (Hochkant↔Querformat) (`develop`)
+
+> Ich habe folgendes Problem, was ich eigentlich lösen würde. Wenn ich eine Map aufmache, zum Beispiel bei Nuernberg, dann ist die Karte hochkant ich muss die aber im Querformat sehen können das heißt es muss möglich sein diese Karte dann wenn ich die in der große Ansicht habe zu drehen. Wenn das nicht klar ist, dann frage bitte nach. Natürlich will ich das nicht nur für diese spezielle Karte, sondern grundsätzlich, dass ich die Karten drehen kann. Wahrscheinlich gibt es noch bei anderen Karten das gleiche Problem.
+
+### 2026-04-26 — Antworten auf Rotations-Feature Fragen (`develop`)
+
+> 1a; 2b; 3c; 4a; 5a; 6a; 7b
+
+### 2026-04-26 — Auto-Orientation: Variante D (weglassen) (`feat/44-chart-rotation`)
+
+> Variante D
+
+### 2026-04-26 — Pinch-Rotate weglassen (`feat/44-chart-rotation`)
+
+> lass pinch rotate weg
+
+### 2026-04-26 — Implementation starten (`feat/44-chart-rotation`)
+
+> leg los
+
+### 2026-04-26 — Bug: Modal flackert + kollabiert nach Rotation (`feat/44-chart-rotation`)
+
+> keln bonn 3 z.B. habe ich gedreht, und seit dem öffnet und schließt sich der view permanent ganz schnell. ist so nicht nutzbar dann. ansonsten funktioniert das drehen eigentlich ganz gut. [Image #1]
+
+### 2026-04-26 — Commit + Housekeeping ausführen (`feat/44-chart-rotation`)
+
+> go - commit and do housekeeping

--- a/docs/ROADMAP_PROGRESS.md
+++ b/docs/ROADMAP_PROGRESS.md
@@ -31,6 +31,7 @@
 - [x] Aerodrome search page — issue #8, paginated, filterable, Vite proxy to gateway
 - [x] Aerodrome detail view — issue #8 + #13 + #17 + #19 (thumbnail grid grouped by chart type, click opens pan/zoom viewer, AIRAC visible per card)
 - [x] Bilingual UI (DE/EN) — issue #8, custom I18nProvider, every string translated, persisted via localStorage
+- [x] Chart rotation in viewer — issue #44 (90°-Schritte L/R/Reset, persistiert pro Chart in `ingest.charts.rotation_degrees`, fit-to-screen via ResizeObserver, Design Kit §23). Pinch-Rotate + Auto-Orientation explizit als Folge-Issues.
 - [ ] Responsive layout — issue #15 (pending go/no-go decision)
 
 ## Phase 2: Enhanced Data & Tools (Planned)

--- a/services/data-ingestion/alembic/versions/20260426_0001_chart_rotation_degrees.py
+++ b/services/data-ingestion/alembic/versions/20260426_0001_chart_rotation_degrees.py
@@ -1,0 +1,46 @@
+"""Add rotation_degrees column to ingest.charts.
+
+Stores the user's preferred rotation for displaying a chart in the viewer.
+Allowed values: 0, 90, 180, 270 (enforced via CHECK constraint).
+
+Revision ID: 20260426_0001
+Revises: 20260420_0002
+Create Date: 2026-04-26
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260426_0001"
+down_revision: Union[str, None] = "20260420_0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "ingest"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "charts",
+        sa.Column(
+            "rotation_degrees",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_check_constraint(
+        "ck_charts_rotation_degrees",
+        "charts",
+        "rotation_degrees IN (0, 90, 180, 270)",
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_charts_rotation_degrees", "charts", schema=SCHEMA, type_="check")
+    op.drop_column("charts", "rotation_degrees", schema=SCHEMA)

--- a/services/data-ingestion/app/api/aerodromes.py
+++ b/services/data-ingestion/app/api/aerodromes.py
@@ -14,7 +14,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.db import get_session_factory
-from app.db.models import Aerodrome
+from app.db.models import Aerodrome, Chart
 from app.core.config import settings
 from shared.schemas import (
     Aerodrome as AerodromeSchema,
@@ -46,6 +46,7 @@ def get_db():
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 
@@ -81,6 +82,7 @@ class ChartRead(BaseModel):
     title_de: str | None
     source_url: str
     preview_url: str | None = None  # computed below
+    rotation_degrees: int = 0
 
     @classmethod
     def from_orm_with_url(cls, chart) -> "ChartRead":
@@ -99,6 +101,7 @@ class ChartRead(BaseModel):
             title_de=chart.title_de,
             source_url=chart.source_url,
             preview_url=preview_url,
+            rotation_degrees=chart.rotation_degrees,
         )
 
 
@@ -201,3 +204,46 @@ def get_aerodrome(
     if row is None:
         raise HTTPException(status_code=404, detail=f"Aerodrome {icao_upper} not found")
     return AerodromeDetail.from_orm_with_urls(row)
+
+
+# --- Chart rotation persistence --- #
+
+
+class ChartRotationUpdate(BaseModel):
+    degrees: Literal[0, 90, 180, 270]
+
+
+class ChartRotationResponse(BaseModel):
+    id: int
+    rotation_degrees: int
+
+
+@router.patch(
+    "/{icao}/charts/{chart_id}/rotation",
+    response_model=ChartRotationResponse,
+    summary="Persist user's preferred rotation for a chart",
+)
+def update_chart_rotation(
+    icao: str,
+    chart_id: int,
+    payload: ChartRotationUpdate,
+    db: Annotated[Session, Depends(get_db)],
+) -> ChartRotationResponse:
+    """Set `rotation_degrees` (0/90/180/270) for a single chart of an aerodrome."""
+    icao_upper = icao.upper()
+    if len(icao_upper) != 4 or not icao_upper.isalpha():
+        raise HTTPException(status_code=400, detail="ICAO must be four letters")
+
+    chart = db.execute(
+        select(Chart).where(Chart.id == chart_id, Chart.aerodrome_icao == icao_upper)
+    ).scalar_one_or_none()
+    if chart is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Chart {chart_id} not found for aerodrome {icao_upper}",
+        )
+
+    chart.rotation_degrees = payload.degrees
+    db.commit()
+    db.refresh(chart)
+    return ChartRotationResponse(id=chart.id, rotation_degrees=chart.rotation_degrees)

--- a/services/data-ingestion/app/db/models/chart.py
+++ b/services/data-ingestion/app/db/models/chart.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from shared.models.base import AiracCycleMixin, TimestampMixin
 from shared.schemas.enums import ChartType
-from sqlalchemy import BigInteger, CHAR, Enum, ForeignKey, Index, Integer, String
+from sqlalchemy import BigInteger, CHAR, CheckConstraint, Enum, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..base import Base
@@ -19,6 +19,10 @@ class Chart(Base, TimestampMixin, AiracCycleMixin):
         Index("ix_charts_aerodrome_icao", "aerodrome_icao"),
         Index("ix_charts_chart_type", "chart_type"),
         Index("ix_charts_source_url", "source_url", unique=True),
+        CheckConstraint(
+            "rotation_degrees IN (0, 90, 180, 270)",
+            name="ck_charts_rotation_degrees",
+        ),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
@@ -44,5 +48,6 @@ class Chart(Base, TimestampMixin, AiracCycleMixin):
     file_size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     language: Mapped[str] = mapped_column(CHAR(2), nullable=False, default="de")
+    rotation_degrees: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     aerodrome: Mapped["Aerodrome"] = relationship(back_populates="charts")

--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -47,6 +47,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -389,6 +390,7 @@
       "version": "18.3.28",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -532,6 +534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -845,6 +848,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -882,6 +886,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -892,6 +897,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -1135,6 +1141,7 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -1480,6 +1487,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/services/frontend/src/api/aerodromes.ts
+++ b/services/frontend/src/api/aerodromes.ts
@@ -1,4 +1,4 @@
-import { apiGetJson, apiListJson, type ApiListResponse } from "./client";
+import { apiGetJson, apiListJson, apiPatchJson, type ApiListResponse } from "./client";
 
 export type AerodromeType =
   | "international"
@@ -78,7 +78,10 @@ export interface Chart {
   title_de: string | null;
   source_url: string;
   preview_url: string | null;
+  rotation_degrees: 0 | 90 | 180 | 270;
 }
+
+export type RotationDegrees = 0 | 90 | 180 | 270;
 
 export interface Notam {
   id: number;
@@ -113,4 +116,12 @@ export function listAerodromes(
 
 export function getAerodrome(icao: string): Promise<AerodromeDetail> {
   return apiGetJson<AerodromeDetail>(`/aerodromes/${icao}`);
+}
+
+export function setChartRotation(
+  icao: string,
+  chartId: number,
+  degrees: RotationDegrees,
+): Promise<{ id: number; rotation_degrees: RotationDegrees }> {
+  return apiPatchJson(`/aerodromes/${icao}/charts/${chartId}/rotation`, { degrees });
 }

--- a/services/frontend/src/api/client.ts
+++ b/services/frontend/src/api/client.ts
@@ -46,3 +46,16 @@ export async function apiPostJson<T>(path: string, body?: unknown): Promise<T> {
   }
   return (await response.json()) as T;
 }
+
+export async function apiPatchJson<T>(path: string, body: unknown): Promise<T> {
+  const url = new URL(`${API_BASE}${path}`, window.location.origin);
+  const response = await fetch(url.toString(), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as T;
+}

--- a/services/frontend/src/components/ChartGrid.tsx
+++ b/services/frontend/src/components/ChartGrid.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 
-import type { Chart } from "@/api/aerodromes";
+import type { Chart, RotationDegrees } from "@/api/aerodromes";
 import { useI18n } from "@/i18n";
 import type { TranslationKey } from "@/i18n/en";
 import { groupChartsByType } from "@/utils/groupChartsByType";
@@ -12,6 +12,8 @@ import { ChartViewer } from "./ChartViewer";
 interface Props {
   charts: Chart[];
   airac: string | null;
+  /** ICAO of the parent aerodrome — used to persist per-chart rotation. */
+  aerodromeIcao?: string;
 }
 
 /**
@@ -20,9 +22,16 @@ interface Props {
  * arrow keys navigate spatially within the flat sequence of cards; focus
  * returns to the opened card when the viewer closes.
  */
-export function ChartGrid({ charts, airac }: Props) {
+export function ChartGrid({ charts, airac, aerodromeIcao }: Props) {
   const { t } = useI18n();
-  const groups = useMemo(() => groupChartsByType(charts), [charts]);
+  // Local mirror so a rotation persisted in the viewer is reflected on
+  // re-opening the same chart, without waiting for a parent refetch.
+  const [chartState, setChartState] = useState<Chart[]>(charts);
+  useEffect(() => {
+    setChartState(charts);
+  }, [charts]);
+
+  const groups = useMemo(() => groupChartsByType(chartState), [chartState]);
   const cardRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [viewerChart, setViewerChart] = useState<Chart | null>(null);
   const [openedIndex, setOpenedIndex] = useState<number | null>(null);
@@ -48,6 +57,12 @@ export function ChartGrid({ charts, airac }: Props) {
   function handleOpen(index: number) {
     setOpenedIndex(index);
     setViewerChart(flat[index].chart);
+  }
+
+  function handleRotationChange(chartId: number, degrees: RotationDegrees) {
+    setChartState((prev) =>
+      prev.map((c) => (c.id === chartId ? { ...c, rotation_degrees: degrees } : c)),
+    );
   }
 
   function handleClose() {
@@ -124,6 +139,10 @@ export function ChartGrid({ charts, airac }: Props) {
         <ChartViewer
           title={viewerChart.title}
           previewUrl={viewerChart.preview_url}
+          chartId={viewerChart.id}
+          aerodromeIcao={aerodromeIcao}
+          initialRotation={viewerChart.rotation_degrees ?? 0}
+          onRotationChange={(deg) => handleRotationChange(viewerChart.id, deg)}
           onClose={handleClose}
         />
       )}

--- a/services/frontend/src/components/ChartViewer.tsx
+++ b/services/frontend/src/components/ChartViewer.tsx
@@ -1,15 +1,23 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   TransformComponent,
   TransformWrapper,
   type ReactZoomPanPinchContentRef,
 } from "react-zoom-pan-pinch";
 
+import { setChartRotation, type RotationDegrees } from "@/api/aerodromes";
+
 interface Props {
   title: string;
   previewUrl: string;
   /** Optional higher-res URL; defaults to swapping _preview -> _print. */
   printUrl?: string;
+  /** Chart identity for persisting rotation. */
+  chartId?: number;
+  aerodromeIcao?: string;
+  initialRotation?: RotationDegrees;
+  /** Notify parent of new persisted rotation, so the cached chart stays in sync. */
+  onRotationChange?: (degrees: RotationDegrees) => void;
   onClose: () => void;
 }
 
@@ -17,16 +25,53 @@ function derivePrintUrl(previewUrl: string): string {
   return previewUrl.replace(/_preview(\.(png|jpg|jpeg))$/i, "_print$1");
 }
 
-export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
+function nextRotation(current: RotationDegrees, delta: 90 | -90): RotationDegrees {
+  const result = (current + delta + 360) % 360;
+  return result as RotationDegrees;
+}
+
+export function ChartViewer({
+  title,
+  previewUrl,
+  printUrl,
+  chartId,
+  aerodromeIcao,
+  initialRotation = 0,
+  onRotationChange,
+  onClose,
+}: Props) {
   const hiRes = printUrl ?? derivePrintUrl(previewUrl);
   const [src, setSrc] = useState(hiRes);
+  const [rotation, setRotation] = useState<RotationDegrees>(initialRotation);
+  const [stageSize, setStageSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // If print version 404s, fall back to the preview.
+  const isQuarterRotated = rotation === 90 || rotation === 270;
+  const canPersist = chartId !== undefined && aerodromeIcao !== undefined;
+
   function handleError() {
     if (src !== previewUrl) setSrc(previewUrl);
   }
 
-  // Esc key closes.
+  function persistRotation(degrees: RotationDegrees) {
+    setRotation(degrees);
+    onRotationChange?.(degrees);
+    if (!canPersist) return;
+    setChartRotation(aerodromeIcao!, chartId!, degrees).catch((err) => {
+      console.error("Failed to persist chart rotation", err);
+    });
+  }
+
+  function rotateLeft() {
+    persistRotation(nextRotation(rotation, -90));
+  }
+  function rotateRight() {
+    persistRotation(nextRotation(rotation, 90));
+  }
+  function resetRotation() {
+    persistRotation(0);
+  }
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
@@ -35,7 +80,6 @@ export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Lock body scroll while viewer is open.
   useEffect(() => {
     const prev = document.body.style.overflow;
     document.body.style.overflow = "hidden";
@@ -43,6 +87,43 @@ export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
       document.body.style.overflow = prev;
     };
   }, []);
+
+  // Measure the visible stage (RZPP wrapper) so we can keep the rotated image
+  // fit-to-screen at 90°/270°. We re-measure only on rotation change and on
+  // window resize — never via ResizeObserver on the stage itself, because the
+  // image's bounds we set in turn affect layout and would cause a feedback loop.
+  useLayoutEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    const stage = root.querySelector(".chart-viewer-stage") as HTMLElement | null;
+    if (!stage) return;
+    const rect = stage.getBoundingClientRect();
+    setStageSize({ w: rect.width, h: rect.height });
+  }, [rotation]);
+
+  useEffect(() => {
+    function onResize() {
+      const root = containerRef.current;
+      if (!root) return;
+      const stage = root.querySelector(".chart-viewer-stage") as HTMLElement | null;
+      if (!stage) return;
+      const rect = stage.getBoundingClientRect();
+      setStageSize({ w: rect.width, h: rect.height });
+    }
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const imgStyle: React.CSSProperties = {
+    transform: `rotate(${rotation}deg)`,
+    transition: "transform 200ms ease",
+  };
+  if (isQuarterRotated && stageSize.w && stageSize.h) {
+    // After a 90/270 rotation the visual width = CSS height and vice versa.
+    // Cap the image's CSS box so the rotated visual fits the un-rotated stage.
+    imgStyle.maxWidth = `${stageSize.h}px`;
+    imgStyle.maxHeight = `${stageSize.w}px`;
+  }
 
   return (
     <div
@@ -52,7 +133,7 @@ export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
       aria-modal="true"
       aria-label={title}
     >
-      <div className="chart-viewer" onClick={(e) => e.stopPropagation()}>
+      <div className="chart-viewer" ref={containerRef} onClick={(e) => e.stopPropagation()}>
         <header className="chart-viewer-head">
           <span className="chart-viewer-title">{title}</span>
           <button
@@ -100,7 +181,33 @@ export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
                   aria-label="Reset zoom"
                   onClick={() => utils.resetTransform()}
                 >
+                  <i className="fa-solid fa-magnifying-glass" />
+                </button>
+                <span className="chart-viewer-controls-divider" aria-hidden="true" />
+                <button
+                  type="button"
+                  className="icon-button"
+                  aria-label="Rotate 90° left"
+                  onClick={rotateLeft}
+                >
                   <i className="fa-solid fa-rotate-left" />
+                </button>
+                <button
+                  type="button"
+                  className="icon-button"
+                  aria-label="Rotate 90° right"
+                  onClick={rotateRight}
+                >
+                  <i className="fa-solid fa-rotate-right" />
+                </button>
+                <button
+                  type="button"
+                  className="icon-button"
+                  aria-label="Reset rotation"
+                  onClick={resetRotation}
+                  disabled={rotation === 0}
+                >
+                  <i className="fa-solid fa-arrows-up-down-left-right" />
                 </button>
               </div>
               <TransformComponent
@@ -113,6 +220,7 @@ export function ChartViewer({ title, previewUrl, printUrl, onClose }: Props) {
                   onError={handleError}
                   draggable={false}
                   className="chart-viewer-image"
+                  style={imgStyle}
                 />
               </TransformComponent>
             </>

--- a/services/frontend/src/pages/AerodromeDetail.tsx
+++ b/services/frontend/src/pages/AerodromeDetail.tsx
@@ -184,7 +184,11 @@ export function AerodromeDetailPage() {
             <div className="card-header">
               <span className="card-title">{t("detail.section.charts")}</span>
             </div>
-            <ChartGrid charts={data.charts} airac={data.source_airac_cycle ?? null} />
+            <ChartGrid
+              charts={data.charts}
+              airac={data.source_airac_cycle ?? null}
+              aerodromeIcao={data.icao}
+            />
           </div>
 
           <div className="card">

--- a/services/frontend/src/styles/global.css
+++ b/services/frontend/src/styles/global.css
@@ -980,6 +980,13 @@ a:hover {
   -webkit-user-select: none;
 }
 
+.chart-viewer-controls-divider {
+  display: block;
+  height: 1px;
+  background: var(--color-border-strong);
+  margin: var(--space-1) 0;
+}
+
 .chart-viewer-foot {
   padding: var(--space-2) var(--space-5);
   border-top: 1px solid var(--color-border-strong);

--- a/services/gateway/app/api/aerodromes.py
+++ b/services/gateway/app/api/aerodromes.py
@@ -103,3 +103,24 @@ async def latest_extraction(icao: str, request: Request):
     if upstream.status_code >= 400:
         raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
     return upstream.json()
+
+
+@router.patch(
+    "/{icao}/charts/{chart_id}/rotation",
+    summary="Persist user's preferred rotation (0/90/180/270) for a chart",
+)
+async def update_chart_rotation(icao: str, chart_id: int, request: Request):
+    body = await request.body()
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        try:
+            upstream = await client.patch(
+                f"{settings.data_ingestion_url}/aerodromes/{icao}/charts/{chart_id}/rotation",
+                content=body,
+                headers={"content-type": request.headers.get("content-type", "application/json")},
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Upstream unreachable: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
+    return upstream.json()


### PR DESCRIPTION
## Summary

Closes #44.

- Adds `rotation_degrees` (0/90/180/270, CHECK-constrained) to `ingest.charts` via Alembic migration `20260426_0001`.
- New `PATCH /aerodromes/{icao}/charts/{chart_id}/rotation` endpoint in data-ingestion; proxied through the gateway.
- Frontend chart viewer toolbar gains three new buttons (rotate-left, rotate-right, reset rotation) below the existing zoom controls, with a divider between the groups.
- Rotation is fit-to-screen at 90°/270° by measuring the stage once on rotation change (`useLayoutEffect`) and on window resize — explicitly **not** via `ResizeObserver` (would feedback-loop with the image's bounds).
- Rotation persists per chart in the DB and is re-applied automatically on re-open.
- Design Kit gains §23 documenting the toolbar.

**Out of scope (explicitly deferred to follow-ups):**
- Pinch-rotate gesture (conflict with pinch-zoom needs separate concept)
- Auto-orientation suggestion
- Hotkeys, thumbnail rotation

## Services affected

- `data-ingestion` (migration, ORM, API)
- `gateway` (proxy)
- `frontend` (ChartViewer, ChartGrid, AerodromeDetail wiring, types/client, CSS)
- Design Kit (§23)

## Test plan

- [x] Backend smoke-tested via curl: GET returns `rotation_degrees`, PATCH 90/180/270/0 persists, invalid (45) → 422, unknown chart → 404.
- [x] Manual UI test: EDDK Koeln Bonn 3 rotated to 90° → persists across viewer re-open. Earlier flicker/collapse bug (BUG-005) fixed.
- [ ] Reviewer to spot-check on EDDN, EDDM, EDDF, EDKA, EDDK if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)