### PR TITLE
[#11] Meilisearch-backed aerodrome search (typo-tolerant, live)

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -223,3 +223,15 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-04-26 — Commit + Housekeeping ausführen (`feat/44-chart-rotation`)
 
 > go - commit and do housekeeping
+
+### 2026-04-26 — Smarte Suche: Teil-ICAO, City-Match, Typo-Toleranz (`develop`)
+
+> ich möchte bei der suche eine smarte suche haben, sodass ich "EDDK / Koeln/Bonn"  auch mit "Köln" der "Bonn" oder vielleicht sogar "DDK" finden kann. Vielleicht geht es auch so smart dass ich beim vertippen sogar Koeln/Bonn finden könnte. z.B. "Boon"
+
+### 2026-04-26 — Antworten Search-Feature (`develop`)
+
+> 1b; 2a; 3b; 4b; 5a; 6a; 7b
+
+### 2026-04-26 — Aufgabe komplett fertig machen (`feat/11-meilisearch-search`)
+
+> ja - mache die aufgabe bis zum ende fertig

--- a/docs/ROADMAP_PROGRESS.md
+++ b/docs/ROADMAP_PROGRESS.md
@@ -18,7 +18,7 @@
 - [ ] Scheduled re-sync jobs — for future AIRAC-cycle updates via the existing scraper
 
 ### Search & API
-- [ ] Meilisearch index configuration (aerodromes, frequencies, charts) — issue #11 (pending go/no-go decision)
+- [x] Meilisearch full-text aerodrome search — issue #11 (typo-tolerant, multi-field, partial-ICAO via icao_search suffix field, German umlaut synonyms, live-search debounced 250ms, fuzzy-match hint in UI). Subscribers receive `aerodrome.upsert`/`.delete` via Redis pub/sub. Frequency/chart/NOTAM index → eigenes Folge-Issue.
 - [x] Gateway REST API — aerodrome listing + detail endpoints — issue #8
 - [x] Full-text prefix search endpoint (ICAO, name) — issue #8 (ILIKE against Postgres)
 - [x] Swagger/OpenAPI documentation — gateway at `/api/docs`, data-ingestion at `/docs`

--- a/services/data-ingestion/app/core/config.py
+++ b/services/data-ingestion/app/core/config.py
@@ -23,6 +23,12 @@ class Settings(BaseSettings):
             f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
         )
 
+    @property
+    def redis_url(self) -> str:
+        if self.redis_password:
+            return f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}/0"
+        return f"redis://{self.redis_host}:{self.redis_port}/0"
+
     class Config:
         env_file = ".env"
 

--- a/services/data-ingestion/app/services/events.py
+++ b/services/data-ingestion/app/services/events.py
@@ -1,0 +1,52 @@
+"""Outbound Redis pub/sub events.
+
+Per CLAUDE.md the data-ingestion service is the source of truth for aerodrome
+data; downstream services (currently: search) subscribe to these channels to
+keep their own indexes/projections in sync. Channel names are kept in sync
+with the search service's `app/sync.py` constants.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import redis
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+CHANNEL_AERODROME_UPSERT = "aerodrome.upsert"
+CHANNEL_AERODROME_DELETE = "aerodrome.delete"
+
+_client: redis.Redis | None = None
+
+
+def _get_client() -> redis.Redis:
+    global _client
+    if _client is None:
+        _client = redis.from_url(settings.redis_url, decode_responses=True)
+    return _client
+
+
+def publish_aerodrome_upsert(icao: str) -> None:
+    """Notify subscribers that aerodrome `icao` was created or modified.
+
+    Best-effort — failures are logged but never propagated; data integrity
+    is in Postgres. The search service's startup bulk-load is the safety
+    net for any missed events.
+    """
+    payload = json.dumps({"icao": icao.upper()})
+    try:
+        _get_client().publish(CHANNEL_AERODROME_UPSERT, payload)
+    except Exception:
+        logger.exception("Failed to publish %s for %s", CHANNEL_AERODROME_UPSERT, icao)
+
+
+def publish_aerodrome_delete(icao: str) -> None:
+    payload = json.dumps({"icao": icao.upper()})
+    try:
+        _get_client().publish(CHANNEL_AERODROME_DELETE, payload)
+    except Exception:
+        logger.exception("Failed to publish %s for %s", CHANNEL_AERODROME_DELETE, icao)

--- a/services/data-ingestion/app/services/extraction_runner.py
+++ b/services/data-ingestion/app/services/extraction_runner.py
@@ -146,6 +146,14 @@ class ExtractionRunner:
             job.current_step = "Fertig"
             job.completed_at = datetime.now(timezone.utc)
             session.commit()
+            # Notify search (and any future subscribers) that this aerodrome
+            # has new data. Best-effort — search's startup bulk-load is the
+            # safety net if Redis is briefly unavailable.
+            try:
+                from app.services.events import publish_aerodrome_upsert
+                publish_aerodrome_upsert(icao)
+            except Exception:
+                log.exception("Failed to publish aerodrome.upsert for %s", icao)
         except Exception as exc:
             log.exception("Extraction job %s failed", job_id)
             session.rollback()

--- a/services/frontend/src/api/aerodromes.ts
+++ b/services/frontend/src/api/aerodromes.ts
@@ -118,6 +118,28 @@ export function getAerodrome(icao: string): Promise<AerodromeDetail> {
   return apiGetJson<AerodromeDetail>(`/aerodromes/${icao}`);
 }
 
+// Meilisearch-backed search hits carry a match_type hint so the UI can flag
+// fuzzy/typo-corrected results.
+export type SearchMatchType = "exact" | "prefix" | "fuzzy";
+
+export interface AerodromeSearchHit extends Aerodrome {
+  match_type: SearchMatchType;
+}
+
+export interface SearchParams {
+  q?: string;
+  type?: AerodromeType;
+  region?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export function searchAerodromes(
+  params: SearchParams,
+): Promise<ApiListResponse<AerodromeSearchHit>> {
+  return apiListJson<AerodromeSearchHit>("/search/aerodromes", { ...params });
+}
+
 export function setChartRotation(
   icao: string,
   chartId: number,

--- a/services/frontend/src/components/AerodromeCard.tsx
+++ b/services/frontend/src/components/AerodromeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-import type { Aerodrome } from "@/api/aerodromes";
+import type { Aerodrome, SearchMatchType } from "@/api/aerodromes";
 import { FrequencyBadge } from "@/components/FrequencyBadge";
 import { useI18n } from "@/i18n";
 
@@ -8,9 +8,11 @@ interface Props {
   aerodrome: Aerodrome;
   runwayCount?: number;
   twrFrequency?: { type: "twr"; value: string | number } | null;
+  /** When provided and equals "fuzzy", show a subtle "similar match" badge. */
+  matchType?: SearchMatchType;
 }
 
-export function AerodromeCard({ aerodrome, runwayCount, twrFrequency }: Props) {
+export function AerodromeCard({ aerodrome, runwayCount, twrFrequency, matchType }: Props) {
   const { t, locale } = useI18n();
   const name = locale === "de" && aerodrome.name_de ? aerodrome.name_de : aerodrome.name;
   const region =
@@ -23,6 +25,12 @@ export function AerodromeCard({ aerodrome, runwayCount, twrFrequency }: Props) {
           <div className="ad-icao">{aerodrome.icao}</div>
           <div className="ad-name">{name}</div>
         </div>
+        {matchType === "fuzzy" && (
+          <span className="match-hint" title={t("search.match.fuzzy.tooltip")}>
+            <i className="fa-solid fa-wand-magic-sparkles" aria-hidden="true" />
+            {t("search.match.fuzzy")}
+          </span>
+        )}
       </div>
       <div className="ad-meta">
         <i className="fa-solid fa-location-dot" aria-hidden="true" />

--- a/services/frontend/src/hooks/useDebounce.ts
+++ b/services/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Debounce a rapidly changing value (e.g. a search input). Returns the most
+ * recent value that has been stable for at least `delayMs` milliseconds.
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(handle);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/services/frontend/src/i18n/de.ts
+++ b/services/frontend/src/i18n/de.ts
@@ -103,6 +103,8 @@ export const de: Record<TranslationKey, string> = {
   "search.pagination.next": "Weiter",
   "search.loading": "Lädt…",
   "search.error": "Flugplätze konnten nicht geladen werden: {message}",
+  "search.match.fuzzy": "Ähnlich",
+  "search.match.fuzzy.tooltip": "Ähnlich zu deiner Eingabe (Tippfehler-tolerant)",
 
   "card.elevation": "Höhe",
   "card.runways": "RWY",

--- a/services/frontend/src/i18n/en.ts
+++ b/services/frontend/src/i18n/en.ts
@@ -106,6 +106,8 @@ export const en = {
   "search.pagination.next": "Next",
   "search.loading": "Loading…",
   "search.error": "Could not load aerodromes: {message}",
+  "search.match.fuzzy": "Similar",
+  "search.match.fuzzy.tooltip": "Similar to your query (typo-tolerant match)",
 
   // Aerodrome card
   "card.elevation": "Elev",

--- a/services/frontend/src/pages/Search.tsx
+++ b/services/frontend/src/pages/Search.tsx
@@ -2,14 +2,16 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import {
-  listAerodromes,
-  type Aerodrome,
+  searchAerodromes,
+  type AerodromeSearchHit,
   type AerodromeType,
 } from "@/api/aerodromes";
 import { AerodromeCard } from "@/components/AerodromeCard";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useI18n } from "@/i18n";
 
 const LIMIT = 24;
+const SEARCH_DEBOUNCE_MS = 250;
 
 function paginationWindow(current: number, total: number): (number | "ellipsis")[] {
   if (total <= 7) return Array.from({ length: total }, (_, i) => i);
@@ -36,11 +38,34 @@ export function SearchPage() {
   const { t } = useI18n();
   const [params, setParams] = useSearchParams();
 
-  const q = params.get("q") ?? "";
+  const urlQ = params.get("q") ?? "";
   const type = (params.get("type") ?? "") as AerodromeType | "";
   const offset = Number(params.get("offset") ?? 0);
 
-  const [items, setItems] = useState<Aerodrome[]>([]);
+  // Local input state — typed character-by-character. Debounced version drives
+  // the actual API call and syncs back into the URL once stable.
+  const [inputQ, setInputQ] = useState(urlQ);
+  const debouncedQ = useDebounce(inputQ, SEARCH_DEBOUNCE_MS);
+
+  // If the URL is changed externally (back/forward, deep link, clear), reflect
+  // that in the input.
+  useEffect(() => {
+    setInputQ(urlQ);
+  }, [urlQ]);
+
+  // Push debounced search term back into the URL — but only if it differs.
+  useEffect(() => {
+    if (debouncedQ === urlQ) return;
+    const p = new URLSearchParams(params);
+    if (debouncedQ) p.set("q", debouncedQ);
+    else p.delete("q");
+    p.delete("offset");
+    setParams(p, { replace: true });
+    // setParams is stable, params is captured at call time intentionally
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQ]);
+
+  const [items, setItems] = useState<AerodromeSearchHit[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,8 +73,8 @@ export function SearchPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    listAerodromes({
-      q: q || undefined,
+    searchAerodromes({
+      q: debouncedQ || undefined,
       type: type || undefined,
       limit: LIMIT,
       offset,
@@ -60,19 +85,15 @@ export function SearchPage() {
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [q, type, offset]);
+  }, [debouncedQ, type, offset]);
 
   const from = total === 0 ? 0 : offset + 1;
   const to = Math.min(offset + items.length, total);
   const page = Math.floor(offset / LIMIT);
   const totalPages = Math.max(1, Math.ceil(total / LIMIT));
 
-  function update(next: Partial<{ q: string; type: string; offset: number }>) {
+  function update(next: Partial<{ type: string; offset: number }>) {
     const p = new URLSearchParams(params);
-    if (next.q !== undefined) {
-      if (next.q) p.set("q", next.q);
-      else p.delete("q");
-    }
     if (next.type !== undefined) {
       if (next.type) p.set("type", next.type);
       else p.delete("type");
@@ -101,8 +122,8 @@ export function SearchPage() {
           className="input"
           style={{ maxWidth: 420 }}
           placeholder={t("search.input.placeholder")}
-          value={q}
-          onChange={(e) => update({ q: e.target.value, offset: 0 })}
+          value={inputQ}
+          onChange={(e) => setInputQ(e.target.value)}
         />
         <select
           className="input"
@@ -141,7 +162,7 @@ export function SearchPage() {
         <>
           <div className="results-grid">
             {items.map((ad) => (
-              <AerodromeCard key={ad.icao} aerodrome={ad} />
+              <AerodromeCard key={ad.icao} aerodrome={ad} matchType={ad.match_type} />
             ))}
           </div>
 

--- a/services/frontend/src/styles/global.css
+++ b/services/frontend/src/styles/global.css
@@ -413,6 +413,21 @@ a:hover {
   gap: var(--space-2);
 }
 
+.aerodrome-card .match-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--color-accent, var(--color-primary));
+  background: color-mix(in oklab, var(--color-accent, var(--color-primary)) 15%, transparent);
+  border: 1px solid color-mix(in oklab, var(--color-accent, var(--color-primary)) 35%, transparent);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill, 999px);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .aerodrome-card .ad-freqs {
   display: flex;
   flex-wrap: wrap;

--- a/services/gateway/app/api/search.py
+++ b/services/gateway/app/api/search.py
@@ -1,0 +1,48 @@
+"""Gateway proxy for the search service."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Response
+
+from app.core.config import settings
+
+router = APIRouter(prefix="/api/search", tags=["search"])
+
+_REQUEST_TIMEOUT = httpx.Timeout(5.0, connect=2.0)
+
+
+@router.get(
+    "/aerodromes",
+    summary="Full-text aerodrome search (typo-tolerant)",
+)
+async def search_aerodromes(
+    response: Response,
+    q: str = Query(default="", description="Search term", max_length=120),
+    type: str | None = Query(default=None, description="Filter by aerodrome type"),
+    region: str | None = Query(default=None, description="Filter by region (EN or DE)", max_length=80),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
+    params: dict[str, str | int] = {"limit": limit, "offset": offset}
+    if q:
+        params["q"] = q
+    if type:
+        params["type"] = type
+    if region:
+        params["region"] = region
+
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        try:
+            upstream = await client.get(
+                f"{settings.search_url}/search/aerodromes",
+                params=params,
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Search upstream unreachable: {exc}") from exc
+
+    if total := upstream.headers.get("x-total-count"):
+        response.headers["X-Total-Count"] = total
+    if upstream.status_code >= 400:
+        raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
+    return upstream.json()

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -8,6 +8,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api.aerodromes import router as aerodromes_router
 from app.api.extraction import router as extraction_router
+from app.api.search import router as search_router
 from app.api.usage import router as usage_router
 from app.core.config import settings
 
@@ -48,6 +49,7 @@ app.add_middleware(RequestIDMiddleware)
 app.include_router(aerodromes_router)
 app.include_router(usage_router)
 app.include_router(extraction_router)
+app.include_router(search_router)
 
 
 @app.get("/api/health", tags=["health"])

--- a/services/search/app/api/aerodromes.py
+++ b/services/search/app/api/aerodromes.py
@@ -1,0 +1,89 @@
+"""GET /search/aerodromes — Meilisearch-backed full-text search."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Query, Response
+
+from app.meili import INDEX_AERODROMES, get_client
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+MatchType = Literal["exact", "prefix", "fuzzy"]
+
+
+def _classify_match(query: str, hit: dict[str, Any]) -> MatchType:
+    """Label a hit as exact / prefix / fuzzy based on its searchable fields.
+
+    Heuristic so the frontend can hint to the user when a result came from
+    typo-tolerant matching versus a direct match. We compare the original
+    query against the hit's searchable fields with case-insensitive logic
+    and a stripped form for diacritic robustness.
+    """
+    q = query.strip().lower()
+    if not q:
+        return "fuzzy"
+    fields = ("icao", "name", "name_de", "city", "city_de")
+    for f in fields:
+        v = hit.get(f)
+        if not isinstance(v, str):
+            continue
+        v_lower = v.lower()
+        if q == v_lower:
+            return "exact"
+        if q in v_lower:
+            # token-prefix or substring counts as "prefix" tier — distinct
+            # from a fuzzy/typo-corrected hit.
+            return "prefix"
+    return "fuzzy"
+
+
+@router.get(
+    "/aerodromes",
+    summary="Full-text aerodrome search (typo-tolerant, multi-field)",
+)
+def search_aerodromes(
+    response: Response,
+    q: str = Query(default="", description="Search term", max_length=120),
+    type: str | None = Query(default=None, description="Filter by aerodrome type"),
+    region: str | None = Query(default=None, description="Filter by region (EN or DE)", max_length=80),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> list[dict[str, Any]]:
+    """Search the aerodromes index. Empty `q` returns the first page in icao order.
+
+    Each hit carries a `match_type` field (`exact` / `prefix` / `fuzzy`) so
+    the UI can show a hint when a result was reached via Meilisearch's
+    typo-tolerance.
+    """
+    client = get_client()
+    index = client.index(INDEX_AERODROMES)
+
+    filter_clauses: list[str] = []
+    if type:
+        # type is an enum value like "international" — Meilisearch needs quoting.
+        safe = type.replace('"', "")
+        filter_clauses.append(f'type = "{safe}"')
+    if region:
+        safe = region.replace('"', "")
+        filter_clauses.append(
+            f'(region = "{safe}" OR region_de = "{safe}")'
+        )
+
+    params: dict[str, Any] = {
+        "limit": limit,
+        "offset": offset,
+        "sort": ["icao:asc"] if not q else None,
+    }
+    if filter_clauses:
+        params["filter"] = " AND ".join(filter_clauses)
+    # Drop None values so meilisearch-py doesn't reject them.
+    params = {k: v for k, v in params.items() if v is not None}
+
+    result = index.search(q, params)
+    hits = result.get("hits", [])
+    total = result.get("estimatedTotalHits", len(hits))
+    response.headers["X-Total-Count"] = str(total)
+
+    return [{**hit, "match_type": _classify_match(q, hit)} for hit in hits]

--- a/services/search/app/core/config.py
+++ b/services/search/app/core/config.py
@@ -12,9 +12,17 @@ class Settings(BaseSettings):
     meili_port: int = 7700
     meili_master_key: str = "changeme_meili_key"
 
+    data_ingestion_url: str = "http://data-ingestion:8001"
+
     @property
     def meili_url(self) -> str:
         return f"http://{self.meili_host}:{self.meili_port}"
+
+    @property
+    def redis_url(self) -> str:
+        if self.redis_password:
+            return f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}/0"
+        return f"redis://{self.redis_host}:{self.redis_port}/0"
 
     class Config:
         env_file = ".env"

--- a/services/search/app/main.py
+++ b/services/search/app/main.py
@@ -1,14 +1,66 @@
 """AeroFly Search — Full-text search over aerodrome data via Meilisearch."""
 
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+
+from app.api.aerodromes import router as aerodromes_router
+from app.meili import ensure_index
+from app.sync import bulk_load, subscribe_loop
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup: ensure index + bulk-load + spawn Redis subscriber.
+
+    Bulk-load failure is logged but non-fatal — the service can still answer
+    queries from whatever's already in Meilisearch (or return empty), and the
+    subscriber will catch up on the next published event.
+    """
+    stop_event = asyncio.Event()
+    subscriber_task: asyncio.Task | None = None
+
+    try:
+        ensure_index()
+    except Exception:
+        logger.exception("Failed to ensure Meilisearch index on startup")
+
+    try:
+        await bulk_load()
+    except Exception:
+        logger.exception("Initial bulk load failed; service will still start")
+
+    subscriber_task = asyncio.create_task(subscribe_loop(stop_event), name="aerodrome-subscriber")
+
+    try:
+        yield
+    finally:
+        stop_event.set()
+        if subscriber_task is not None:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
 
 app = FastAPI(
     title="AeroFly Search",
     description="Search service for aerodrome data — powered by Meilisearch.",
-    version="0.1.0",
+    version="0.2.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
+
+app.include_router(aerodromes_router)
 
 
 @app.get("/health", tags=["health"])

--- a/services/search/app/meili.py
+++ b/services/search/app/meili.py
@@ -1,0 +1,138 @@
+"""Meilisearch client + index lifecycle for the aerodromes index.
+
+Single source of truth for index name, schema, synonyms, and ranking config.
+Idempotent — `ensure_index()` is safe to call repeatedly on every cold start.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import meilisearch
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+INDEX_AERODROMES = "aerodromes"
+PRIMARY_KEY = "icao"
+
+# Fields that can match a query, in priority order.
+# `icao_search` is a derived field that pre-expands the ICAO into its useful
+# suffixes ("EDDK DDK DK") so Meilisearch's token-prefix matcher can satisfy
+# partial-ICAO queries like "DDK" → "EDDK".
+SEARCHABLE_ATTRIBUTES = [
+    "icao",
+    "icao_search",
+    "name",
+    "name_de",
+    "city",
+    "city_de",
+]
+
+# Fields returned with hits (everything we may want to render).
+DISPLAYED_ATTRIBUTES = [
+    "icao",
+    "iata",
+    "name",
+    "name_de",
+    "city",
+    "city_de",
+    "region",
+    "region_de",
+    "country",
+    "type",
+    "latitude",
+    "longitude",
+    "elevation_ft",
+]
+
+FILTERABLE_ATTRIBUTES = ["type", "country", "region", "region_de"]
+SORTABLE_ATTRIBUTES = ["icao"]
+
+# German umlaut/diacritic ↔ ASCII transliteration. Meilisearch normalizes
+# diacritics natively (Köln → kln), but native normalization does NOT cover
+# the German "ö → oe" rule pilots actually use. Synonyms close that gap so
+# typing "Koeln" still finds "Köln" and vice versa.
+SYNONYMS: dict[str, list[str]] = {
+    "koeln": ["köln"],
+    "köln": ["koeln"],
+    "muenchen": ["münchen"],
+    "münchen": ["muenchen"],
+    "duesseldorf": ["düsseldorf"],
+    "düsseldorf": ["duesseldorf"],
+    "nuernberg": ["nürnberg"],
+    "nürnberg": ["nuernberg"],
+    "saarbruecken": ["saarbrücken"],
+    "saarbrücken": ["saarbruecken"],
+    "tuebingen": ["tübingen"],
+    "tübingen": ["tuebingen"],
+    "luebeck": ["lübeck"],
+    "lübeck": ["luebeck"],
+    "ruegen": ["rügen"],
+    "rügen": ["ruegen"],
+    "wuerzburg": ["würzburg"],
+    "würzburg": ["wuerzburg"],
+    "guetersloh": ["gütersloh"],
+    "gütersloh": ["guetersloh"],
+    "zuerich": ["zürich"],
+    "zürich": ["zuerich"],
+}
+
+
+_client: meilisearch.Client | None = None
+
+
+def get_client() -> meilisearch.Client:
+    global _client
+    if _client is None:
+        _client = meilisearch.Client(settings.meili_url, settings.meili_master_key)
+    return _client
+
+
+def ensure_index() -> None:
+    """Create the aerodromes index if missing and apply settings.
+
+    Safe to call on every startup — Meilisearch updates settings only when
+    they actually change, and `create_index` returns 202 + accepted task even
+    if the index already exists (we ignore that branch).
+    """
+    client = get_client()
+    try:
+        client.create_index(INDEX_AERODROMES, {"primaryKey": PRIMARY_KEY})
+        logger.info("Created Meilisearch index %r", INDEX_AERODROMES)
+    except meilisearch.errors.MeilisearchApiError as exc:
+        # 4xx with code "index_already_exists" is expected on warm starts.
+        if getattr(exc, "code", None) != "index_already_exists":
+            raise
+
+    index = client.index(INDEX_AERODROMES)
+    index.update_searchable_attributes(SEARCHABLE_ATTRIBUTES)
+    index.update_displayed_attributes(DISPLAYED_ATTRIBUTES)
+    index.update_filterable_attributes(FILTERABLE_ATTRIBUTES)
+    index.update_sortable_attributes(SORTABLE_ATTRIBUTES)
+    index.update_synonyms(SYNONYMS)
+    # Default typo tolerance only kicks in at 5+ chars for one typo and 9+
+    # for two; lowering both lets short city/airport names ("Bonn", "Hahn")
+    # tolerate a single typo too ("Boon" → "Bonn").
+    index.update_typo_tolerance(
+        {
+            "enabled": True,
+            "minWordSizeForTypos": {"oneTypo": 4, "twoTypos": 8},
+        }
+    )
+    logger.info("Applied Meilisearch settings to %r", INDEX_AERODROMES)
+
+
+def upsert_documents(docs: list[dict[str, Any]]) -> None:
+    """Add or update documents in bulk. Meilisearch handles upsert by primaryKey."""
+    if not docs:
+        return
+    index = get_client().index(INDEX_AERODROMES)
+    index.add_documents(docs, primary_key=PRIMARY_KEY)
+
+
+def delete_document(icao: str) -> None:
+    index = get_client().index(INDEX_AERODROMES)
+    index.delete_document(icao.upper())

--- a/services/search/app/sync.py
+++ b/services/search/app/sync.py
@@ -1,0 +1,172 @@
+"""Sync the Meilisearch aerodromes index with data-ingestion.
+
+Two flows:
+1. Bulk load on startup — fetch the full list from data-ingestion's HTTP API
+   and re-index. Per CLAUDE.md ("Database per module") the search service
+   never reads `ingest.aerodromes` directly; it only consumes the data via
+   the data-ingestion service.
+2. Delta updates — Redis pub/sub subscriber that re-indexes a single
+   aerodrome when data-ingestion publishes `aerodrome.upsert {icao}`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import httpx
+import redis.asyncio as aioredis
+
+from app.core.config import settings
+from app.meili import delete_document, upsert_documents
+
+logger = logging.getLogger(__name__)
+
+CHANNEL_AERODROME_UPSERT = "aerodrome.upsert"
+CHANNEL_AERODROME_DELETE = "aerodrome.delete"
+
+# Fields we project from data-ingestion's aerodrome JSON into the Meilisearch
+# document. Anything outside this list is dropped to keep the index lean.
+_INDEXED_FIELDS = {
+    "icao",
+    "iata",
+    "name",
+    "name_de",
+    "city",
+    "city_de",
+    "region",
+    "region_de",
+    "country",
+    "type",
+    "latitude",
+    "longitude",
+    "elevation_ft",
+}
+
+
+def _icao_search_field(icao: str | None) -> str:
+    """Pre-expand the ICAO into matchable suffixes for the Meilisearch index.
+
+    Meilisearch's token-prefix matcher won't satisfy `q="DDK"` on `icao="EDDK"`
+    on its own (DDK is not a prefix of EDDK). Listing the trailing 3- and
+    2-char suffixes alongside the full ICAO turns it into a prefix match.
+    """
+    if not isinstance(icao, str) or len(icao) < 2:
+        return icao or ""
+    parts = [icao]
+    for n in (3, 2):
+        if len(icao) > n:
+            parts.append(icao[-n:])
+    return " ".join(parts)
+
+
+def _project(aerodrome: dict[str, Any]) -> dict[str, Any]:
+    """Project a data-ingestion aerodrome record onto the Meilisearch schema."""
+    doc = {k: aerodrome.get(k) for k in _INDEXED_FIELDS if k in aerodrome}
+    doc["icao_search"] = _icao_search_field(aerodrome.get("icao"))
+    return doc
+
+
+async def bulk_load() -> int:
+    """Fetch every aerodrome from data-ingestion and re-index. Returns count."""
+    url = f"{settings.data_ingestion_url}/aerodromes"
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=5.0)) as client:
+        # 433 fits in one page; the limit cap is 200 per call so we paginate.
+        items: list[dict[str, Any]] = []
+        offset = 0
+        page = 200
+        while True:
+            resp = await client.get(url, params={"limit": page, "offset": offset})
+            resp.raise_for_status()
+            chunk = resp.json()
+            if not chunk:
+                break
+            items.extend(chunk)
+            if len(chunk) < page:
+                break
+            offset += page
+
+    docs = [_project(a) for a in items]
+    upsert_documents(docs)
+    logger.info("Bulk-loaded %d aerodromes into Meilisearch", len(docs))
+    return len(docs)
+
+
+async def reindex_one(icao: str) -> None:
+    """Fetch a single aerodrome and upsert it into Meilisearch."""
+    url = f"{settings.data_ingestion_url}/aerodromes/{icao.upper()}"
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=3.0)) as client:
+        resp = await client.get(url)
+        if resp.status_code == 404:
+            delete_document(icao)
+            logger.info("Removed %s from index (404 from data-ingestion)", icao)
+            return
+        resp.raise_for_status()
+        aerodrome = resp.json()
+    upsert_documents([_project(aerodrome)])
+    logger.info("Re-indexed %s", icao.upper())
+
+
+async def _handle_message(channel: str, payload: str) -> None:
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning("Ignoring non-JSON message on %s: %r", channel, payload)
+        return
+    icao = data.get("icao")
+    if not isinstance(icao, str) or len(icao) != 4:
+        logger.warning("Ignoring message without valid icao on %s: %r", channel, data)
+        return
+    try:
+        if channel == CHANNEL_AERODROME_DELETE:
+            delete_document(icao)
+        else:
+            await reindex_one(icao)
+    except Exception:
+        logger.exception("Failed to process %s message for %s", channel, icao)
+
+
+async def subscribe_loop(stop_event: asyncio.Event) -> None:
+    """Long-running task: subscribe to aerodrome.* channels and react.
+
+    Reconnects on connection drop. Exits cleanly when `stop_event` is set.
+    """
+    backoff = 1.0
+    while not stop_event.is_set():
+        try:
+            client = aioredis.from_url(settings.redis_url, decode_responses=True)
+            pubsub = client.pubsub()
+            await pubsub.subscribe(CHANNEL_AERODROME_UPSERT, CHANNEL_AERODROME_DELETE)
+            logger.info(
+                "Subscribed to Redis channels: %s, %s",
+                CHANNEL_AERODROME_UPSERT,
+                CHANNEL_AERODROME_DELETE,
+            )
+            backoff = 1.0
+            async for msg in pubsub.listen():
+                if stop_event.is_set():
+                    break
+                if msg.get("type") != "message":
+                    continue
+                channel = msg.get("channel")
+                payload = msg.get("data")
+                if isinstance(channel, str) and isinstance(payload, str):
+                    await _handle_message(channel, payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Redis subscriber crashed; retrying in %.1fs", backoff)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, 30.0)
+        finally:
+            try:
+                await pubsub.unsubscribe()
+                await pubsub.aclose()
+                await client.aclose()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

Closes #11.

Wires up the previously stubbed search service into a real Meilisearch-backed search:

- **Index** `aerodromes` with searchable attrs `icao`, `icao_search` (derived suffix field), `name`, `name_de`, `city`, `city_de`. German umlaut synonyms (`Köln↔Koeln`, `München↔Muenchen` etc.). Typo tolerance lowered to `oneTypo: 4` / `twoTypos: 8` so short names still tolerate one mistake.
- **icao_search** trick: lists trailing 3- and 2-char suffixes of the ICAO alongside the full code so `DDK` prefix-matches `EDDK` (Meilisearch only does token-prefix, not substring).
- **Sync**: search service `bulk_load()` calls `data-ingestion /aerodromes` on startup. Per CLAUDE.md DB-per-module rule it never reads `ingest.aerodromes` directly. Subscribes to Redis channels `aerodrome.upsert` and `aerodrome.delete`.
- **Publishing**: data-ingestion publishes `aerodrome.upsert {icao}` after a successful extraction job completes.
- **Gateway proxy**: `GET /api/search/aerodromes` forwards to search service.
- **Frontend**: search page switches to the new endpoint with a 250 ms debounce. Results carry a `match_type` (`exact` | `prefix` | `fuzzy`); fuzzy hits get a subtle "Ähnlich" / "Similar" pill on the card.

## Test plan

Verified via curl through the gateway (`http://localhost:8080/api/search/aerodromes?q=…`):

- [x] `bonn` → finds EDDK + EDKB
- [x] `DDK` → finds EDDK
- [x] `Köln` → finds EDDK
- [x] `Koeln` (no umlaut) → finds EDDK (synonym)
- [x] `Boon` (typo) → finds EDDK (fuzzy)
- [x] `Fankfurt` (typo) → finds EDDF, EDFE, EDFH (fuzzy)
- [x] `Münhen` (typo) → finds EDDM (fuzzy)
- [x] match_type field correctly classifies exact/prefix/fuzzy
- [x] Bulk-load on startup indexes all 433 aerodromes
- [x] Redis subscriber connects and listens
- [ ] Reviewer to spot-check live-search debounce + UI badge in the browser

## Out of scope (deferred)

- Charts/frequencies/NOTAM index (eigenes Issue)
- Phonetic search (Soundex/Metaphone)
- Auto-orientation suggestions in the chart viewer (deferred from #44)
- Pinch-rotate (deferred from #44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)