### PR TITLE
[#51] fix: dynamic DNS resolution for nginx upstreams

### DIFF
--- a/docs/BUG_REGISTRY.md
+++ b/docs/BUG_REGISTRY.md
@@ -30,12 +30,13 @@ Each entry:
 - **Affected files**: `services/data-ingestion/alembic/env.py`, `services/search/alembic/env.py`, `services/gateway/alembic/env.py`
 - **Commit/PR**: #4
 
-### [BUG-003] nginx returns 502 for /api/* after rebuilding gateway/data-ingestion
+### [BUG-003] nginx returns 502 for /api/* after rebuilding gateway/data-ingestion — **FIXED #51 / PR pending**
 - **Symptom**: Frontend looks broken after `docker compose up --build -d` touches a backend service. Static assets load (React app renders), but every `/api/*` call returns 502. `docker compose ps` shows all services healthy.
 - **Root cause**: nginx resolves upstream hostnames once at startup and caches the IPs. When a backend container is recreated, it gets a new internal IP on the compose network; nginx keeps trying the old IP and the kernel returns `connect() failed (111: Connection refused)` to nginx, which replies 502 to the client.
-- **Fix**: `docker compose restart nginx` after any rebuild that recreated a backend container. Long-term fix: either (a) add a `resolver` directive in the nginx config with a short TTL + use variables in `proxy_pass`, or (b) always `up --build` nginx alongside the backends so it restarts too.
-- **Affected files**: `deploy/nginx/*.conf`, runbook step 9.
-- **Commit/PR**: discovered during #32 spike validation.
+- **Workaround (pre-fix)**: `docker compose restart nginx` after any rebuild that recreated a backend container.
+- **Permanent fix (issue #51)**: `infrastructure/nginx/nginx.conf` now uses Docker's embedded DNS (`resolver 127.0.0.11 valid=10s ipv6=off;`) plus variable-based `proxy_pass` (e.g. `set $upstream_gateway "gateway:8000"; proxy_pass http://$upstream_gateway$request_uri;`). Variable-form `proxy_pass` forces nginx to re-resolve the hostname at request time (cached for 10 s) rather than once at startup. Backends can now be rebuilt without a nginx restart — the new IP is picked up automatically within ~10 s.
+- **Affected files**: `infrastructure/nginx/nginx.conf`.
+- **Commit/PR**: discovered during #32 spike validation, recurred during #47 housekeeping, fixed via #51.
 
 ### [BUG-004] Manifest-driven chart_selector returns empty on pre-#30 manifests
 - **Symptom**: After merging #32, running the extraction spike reports `"no chart matched the field group's accepted chart_types"` for every aerodrome — even though `data/aerodromes/<ICAO>/manifest.json` exists.

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -275,3 +275,11 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-05-02 13:25 — Housekeeping ausführen (`feat/47-print-documents`)
 
 > perfekt - do housekeeping
+
+### 2026-05-02 14:00 — Bug: Suche liefert keine Flugplätze nach Rebuild (`develop`)
+
+> Ich bekomme überhaupt keine Flugplätze mehr, egal ob ich Frankfurt oder Hamburg eingebe, ich bekomme nichts mehr angezeigt.
+
+### 2026-05-02 14:10 — Permanenter Fix für BUG-003 (nginx DNS-Cache) (`develop`)
+
+> a

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -283,3 +283,7 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 ### 2026-05-02 14:10 — Permanenter Fix für BUG-003 (nginx DNS-Cache) (`develop`)
 
 > a
+
+### 2026-05-02 14:30 — Mergen + Housekeeping (`fix/51-nginx-dynamic-dns`)
+
+> ja - mergen und houskeeping

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -1,14 +1,9 @@
-upstream gateway {
-    server gateway:8000;
-}
-
-upstream data_ingestion {
-    server data-ingestion:8001;
-}
-
-upstream frontend {
-    server frontend:3000;
-}
+# Use Docker's embedded DNS (127.0.0.11) for runtime hostname resolution.
+# Combined with variable-based `proxy_pass` (see below), this forces nginx to
+# re-resolve backend container IPs per request (cached for `valid=10s`),
+# instead of resolving once at startup. Eliminates BUG-003: no more 502s
+# after a backend container is rebuilt or recreated. See BUG_REGISTRY.md.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 server {
     listen 80;
@@ -17,8 +12,9 @@ server {
     # Binary chart images: bypass gateway (no JSON layer), go straight to
     # data-ingestion and cache. Must be defined BEFORE the generic /api/ block.
     location /api/charts/ {
+        set $upstream_data_ingestion "data-ingestion:8001";
         rewrite ^/api/charts/(.*)$ /charts/$1 break;
-        proxy_pass http://data_ingestion;
+        proxy_pass http://$upstream_data_ingestion;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -28,7 +24,8 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://gateway;
+        set $upstream_gateway "gateway:8000";
+        proxy_pass http://$upstream_gateway$request_uri;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -36,8 +33,10 @@ server {
     }
 
     location / {
-        proxy_pass http://frontend;
+        set $upstream_frontend "frontend:3000";
+        proxy_pass http://$upstream_frontend$request_uri;
         proxy_set_header Host $host;
+        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }


### PR DESCRIPTION
Closes #51.

## Summary

Permanently fixes BUG-003 — no more `502 Bad Gateway` after rebuilding a backend container. nginx now uses Docker's embedded DNS (`127.0.0.11`) and variable-based `proxy_pass` so backend IPs are re-resolved per request (cached for 10 s) instead of once at startup.

## Changes

- `infrastructure/nginx/nginx.conf` — drop `upstream` blocks, add `resolver 127.0.0.11 valid=10s ipv6=off;`, switch each `proxy_pass` to `set \$upstream "host:port"; proxy_pass http://\$upstream\$request_uri;`. The chart-rewrite location (`/api/charts/`) keeps its `rewrite ... break;` (no `\$request_uri` needed there).
- `docs/BUG_REGISTRY.md` — BUG-003 marked as fixed by this PR with the technical detail.

## Verification

Done locally before pushing:

1. Reload new nginx config (`docker compose restart nginx`) → `/`, `/api/aerodromes`, `/api/search/aerodromes`, `/api/charts/...` all return 200.
2. **The actual proof**: `docker compose up --build -d gateway --force-recreate` (new container IP) **without touching nginx** → `/api/aerodromes` returns 200 within ~12 s. Pre-fix this would have been 502 indefinitely until manual `restart nginx`.

## Out of scope

- Compose `depends_on: <svc>: restart: true` was considered as alternative — works for compose-orchestrated restarts but doesn't cover crash-recovery, which the resolver approach handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)