### PR TITLE
[#59] fix: frontend Dockerfile uses npm install instead of npm ci

### DIFF
--- a/docs/BUG_REGISTRY.md
+++ b/docs/BUG_REGISTRY.md
@@ -66,6 +66,13 @@ Each entry:
 - **Affected files**: `services/frontend/src/styles/global.css`, `services/frontend/src/utils/printDocuments.ts`
 - **Commit/PR**: #47 (caught immediately after BUG-006 fix during EDDV multi-print re-test — fixed before merge).
 
+### [BUG-010] Frontend Docker image build fails on Linux/macOS — `npm ci` rejects Windows-locked package-lock.json
+- **Symptom**: `docker compose up --build -d` fails on Linux/macOS with `target frontend: failed to solve: process "/bin/sh -c npm ci --no-audit --no-fund" did not complete successfully: exit code: 1`. Running container keeps working because the source is volume-mounted and the previous image layer is cached, but any fresh clone or image push breaks.
+- **Root cause**: Same as BUG-008. `package-lock.json` is generated on Windows; npm only writes the `@rollup/rollup-win32-x64-msvc` binary into the lockfile's `optionalDependencies`. `npm ci` strictly follows the lockfile and never installs the Linux/macOS rollup binary, so Rollup crashes loading its native bindings during install — but only the CI workflow had the workaround; the Dockerfile still ran the bare `npm ci`.
+- **Fix**: Mirror the CI workaround into `services/frontend/Dockerfile`: replace `npm ci --no-audit --no-fund` with `rm -rf node_modules package-lock.json && npm install --no-audit --no-fund`. Cross-platform rollup binaries are already in `package.json` `optionalDependencies` (added by BUG-008 fix), so `npm install` resolves the right one on whichever host builds the image.
+- **Affected files**: `services/frontend/Dockerfile`
+- **Commit/PR**: #59 → fix branch `fix/59-frontend-dockerfile-npm-install` (caught during PR #56 housekeeping rebuild verification).
+
 ### [BUG-009] Gateway `/api/favorites` returns 500 after pytest run in shared Postgres
 - **Symptom**: After running `pytest services/gateway/tests/` against the dev compose stack, `GET /api/favorites` returns 500 with `relation "gateway.favorites" does not exist`, even though `alembic current` still reports `20260516_0002` (head). `\dt gateway.*` confirms the table is gone but `gateway.alembic_version` still says head.
 - **Root cause**: `services/gateway/conftest.py` had `Base.metadata.drop_all(bind=engine)` in its session-scoped teardown. The dev pytest run shares the Postgres instance with the running dev stack — when the test session ended, `drop_all` removed `gateway.favorites` from the live DB. Alembic's `alembic_version` is not in `Base.metadata`, so its row stayed at `20260516_0002` and reported a false "head" state. Subsequent gateway requests then hit the missing table.

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -324,4 +324,12 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 
 > ja
 
+### 2026-05-16 — Frage: Issue 1 und 2 gefixt? (`develop`)
+
+> Hast du Issue 1 und 2 gefixt?
+
+### 2026-05-16 — Issue + Fix für Frontend-Dockerfile npm ci Problem (`develop`)
+
+> ja, mach Issue und Fix
+
 

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -3,7 +3,12 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci --no-audit --no-fund
+# Workaround for npm/cli#4828 — see BUG-008 / BUG-010 in docs/BUG_REGISTRY.md.
+# A package-lock.json regenerated on Windows only locks the win32 rollup
+# binary; npm ci would never resolve the Linux/macOS one and the build fails.
+# Dropping the lockfile + node_modules lets npm pick the right platform binary
+# (backed by optionalDependencies in package.json) on whichever host builds.
+RUN rm -rf node_modules package-lock.json && npm install --no-audit --no-fund
 
 COPY . .
 


### PR DESCRIPTION
Closes #59.

## Summary
Frontend `docker compose build frontend` failed on Linux/macOS when `package-lock.json` had last been regenerated on Windows — same root cause as BUG-008 (Windows-only rollup binary locked into the file). The CI workflow already mirrors this workaround; the Dockerfile didn't.

Replaced `RUN npm ci --no-audit --no-fund` with `RUN rm -rf node_modules package-lock.json && npm install --no-audit --no-fund`. Cross-platform rollup binaries are already in `package.json` `optionalDependencies` (BUG-008 fix), so `npm install` picks the correct host binary at build time.

Documented as **BUG-010** in `docs/BUG_REGISTRY.md`.

## Services affected
- `services/frontend/Dockerfile`

## Test plan
- [x] `docker compose build frontend` succeeds on Linux/WSL host with a Windows-generated lockfile
- [x] `docker compose up -d frontend` recreates the container without errors
- [x] `curl http://localhost:13000/search` → 200
- [x] Vite dev server still serves on `0.0.0.0:3000` inside the container