### PR TITLE
[#61] feat: dashboard favorites widget with compact aerodrome cards

### DIFF
--- a/docs/Design-Kits/aerofly-design-kit.html
+++ b/docs/Design-Kits/aerofly-design-kit.html
@@ -859,6 +859,111 @@
     }
     .fav-toggle.just-added { animation: fav-pulse var(--duration-base) ease-out; }
 
+    /* --- Aerodrome Card — Compact (Design Kit §28)
+       Modifier on .aerodrome-card. Single-row "flight strip" aesthetic with a
+       3px primary spine on the left edge. Re-uses .ad-icao / .ad-name / .ad-meta
+       names but the DOM is flatter (one grid row, no .ad-head wrapper). */
+    .aerodrome-card.aerodrome-card--compact {
+      display: grid;
+      grid-template-columns: auto 1fr auto auto;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-2) var(--space-4) var(--space-2) 0;
+      border-radius: var(--radius-md);
+      min-height: 56px;
+      position: relative;
+      overflow: hidden;
+      transition: background var(--duration-fast), border-color var(--duration-fast);
+    }
+    .aerodrome-card.aerodrome-card--compact:hover,
+    .aerodrome-card.aerodrome-card--compact:focus-visible {
+      transform: none;
+      background: var(--color-surface-2);
+      border-color: var(--color-border-strong);
+      box-shadow: none;
+      text-decoration: none;
+    }
+    .aerodrome-card.aerodrome-card--compact:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+
+    /* Signature spine — saturates from primary-soft to primary on hover/focus. */
+    .aerodrome-card.aerodrome-card--compact::before {
+      content: "";
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 3px;
+      background: var(--color-primary-soft);
+      transition: background var(--duration-fast);
+    }
+    .aerodrome-card.aerodrome-card--compact:hover::before,
+    .aerodrome-card.aerodrome-card--compact:focus-visible::before {
+      background: var(--color-primary);
+    }
+
+    /* ICAO — deliberately smaller than full card (fs-base vs fs-2xl) so 6 rows
+       don't shout. min-width keeps the name column aligned across rows. */
+    .aerodrome-card.aerodrome-card--compact .ad-icao {
+      font-family: var(--font-mono);
+      font-size: var(--fs-base);
+      font-weight: var(--fw-bold);
+      color: var(--color-primary);
+      letter-spacing: -0.02em;
+      padding-left: var(--space-4);
+      min-width: 76px;
+    }
+
+    .aerodrome-card.aerodrome-card--compact .ad-body {
+      display: flex;
+      align-items: baseline;
+      gap: var(--space-2);
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+    .aerodrome-card.aerodrome-card--compact .ad-name {
+      font-size: var(--fs-sm);
+      font-weight: var(--fw-semibold);
+      color: var(--color-text);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .aerodrome-card.aerodrome-card--compact .ad-meta {
+      font-size: var(--fs-xs);
+      color: var(--color-text-muted);
+      flex-shrink: 0;
+      display: inline;
+    }
+    .aerodrome-card.aerodrome-card--compact .ad-meta::before {
+      content: "·";
+      margin-right: var(--space-2);
+      color: var(--color-border-strong);
+    }
+
+    .aerodrome-card.aerodrome-card--compact .ad-signals {
+      display: inline-flex;
+      gap: var(--space-3);
+      font-family: var(--font-mono);
+      font-size: var(--fs-xs);
+      color: var(--color-text-secondary);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .aerodrome-card.aerodrome-card--compact .ad-stat {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .aerodrome-card.aerodrome-card--compact .ad-stat i {
+      color: var(--color-text-muted);
+      font-size: 10px;
+    }
+
+    @media (max-width: 540px) {
+      .aerodrome-card.aerodrome-card--compact .ad-signals { display: none; }
+    }
+
     /* --- Tab Switch Count Badge (extends .tab) --- */
     .tab .tab-count {
       display: inline-block;
@@ -1364,6 +1469,7 @@
         <li><a href="#sec-25">25. Favorite Toggle</a></li>
         <li><a href="#sec-26">26. Tab Switch</a></li>
         <li><a href="#sec-27">27. Empty State</a></li>
+        <li><a href="#sec-28">28. Aerodrome Card (Compact)</a></li>
       </ul>
     </aside>
 
@@ -3007,6 +3113,77 @@
           <li>Headline + Body sind übersetzbar; das Icon bleibt gleich (sprachneutral).</li>
           <li>CTA ist optional — wenn keine sinnvolle nächste Aktion existiert, weglassen.</li>
           <li>Bilingual-Keys für den Favoriten-Empty-State: <code>favorites.empty.title</code>, <code>favorites.empty.body</code>, <code>favorites.empty.cta</code>.</li>
+        </ul>
+      </section>
+
+      <!-- ================================================================ -->
+      <!-- 28. Aerodrome Card (Compact)                                      -->
+      <!-- ================================================================ -->
+      <section class="kit-section" id="sec-28">
+        <h2><span class="sec-num">28</span>Aerodrome Card (Compact)</h2>
+        <p class="sec-desc">
+          Listenkompakte Variante der <code>.aerodrome-card</code> für Widgets, die mehrere Favoriten
+          untereinander stapeln (Übersicht-Favoriten-Panel, später ggf. Sidebar-Pinned-List, Mobile-Drawer).
+          Modifier-Klasse <code>.aerodrome-card--compact</code> auf <code>.aerodrome-card</code> —
+          teilt sich die semantischen Klassen <code>.ad-icao</code>, <code>.ad-name</code>,
+          <code>.ad-meta</code> mit der Voll-Variante, hat aber ein flacheres DOM (eine Grid-Zeile,
+          kein <code>.ad-head</code>-Wrapper, kein <code>.ad-stats</code>-Footer).
+          Signatur-Element: die 3&nbsp;px Akzent-Spine am linken Rand (<code>::before</code>) — sättigt
+          im Hover auf <code>--color-primary</code> und ist der visuelle Anker für „dies ist ein
+          Listen-Item, keine Ergebnis-Kachel". Zeilenhöhe ≥ 56&nbsp;px, single-row, ICAO + Name +
+          Region + zwei Sekundär-Signalen (TWR-Frequenz, RWY-Count) + Stern. Click triggert
+          Detail-Navigation; Stern stoppt Propagation.
+        </p>
+        <div class="kit-preview block" style="display:flex; flex-direction:column; gap:var(--space-2); max-width:640px;">
+          <a href="#sec-28" class="aerodrome-card aerodrome-card--compact" onclick="event.preventDefault()">
+            <div class="ad-icao">EDDF</div>
+            <div class="ad-body">
+              <span class="ad-name">Frankfurt am Main</span>
+              <span class="ad-meta">Hessen · International</span>
+            </div>
+            <div class="ad-signals">
+              <span class="ad-stat" title="Tower frequency"><i class="fa-solid fa-tower-broadcast"></i> 119.900</span>
+              <span class="ad-stat" title="Runways"><i class="fa-solid fa-road"></i> 4</span>
+            </div>
+            <button type="button" class="fav-toggle fav-toggle--sm is-active" aria-pressed="true" aria-label="Aus Favoriten entfernen">
+              <i class="fa-solid fa-star"></i>
+            </button>
+          </a>
+          <a href="#sec-28" class="aerodrome-card aerodrome-card--compact" onclick="event.preventDefault()">
+            <div class="ad-icao">EDDM</div>
+            <div class="ad-body">
+              <span class="ad-name">München</span>
+              <span class="ad-meta">Bayern · International</span>
+            </div>
+            <div class="ad-signals">
+              <span class="ad-stat"><i class="fa-solid fa-tower-broadcast"></i> 118.700</span>
+              <span class="ad-stat"><i class="fa-solid fa-road"></i> 2</span>
+            </div>
+            <button type="button" class="fav-toggle fav-toggle--sm is-active" aria-pressed="true" aria-label="Aus Favoriten entfernen">
+              <i class="fa-solid fa-star"></i>
+            </button>
+          </a>
+          <a href="#sec-28" class="aerodrome-card aerodrome-card--compact" onclick="event.preventDefault()">
+            <div class="ad-icao">EDDH</div>
+            <div class="ad-body">
+              <span class="ad-name">Hamburg</span>
+              <span class="ad-meta">Hamburg · International</span>
+            </div>
+            <div class="ad-signals">
+              <span class="ad-stat"><i class="fa-solid fa-tower-broadcast"></i> 126.900</span>
+              <span class="ad-stat"><i class="fa-solid fa-road"></i> 2</span>
+            </div>
+            <button type="button" class="fav-toggle fav-toggle--sm is-active" aria-pressed="true" aria-label="Aus Favoriten entfernen">
+              <i class="fa-solid fa-star"></i>
+            </button>
+          </a>
+        </div>
+        <ul style="font-size:var(--fs-sm); color:var(--color-text-muted); margin-top:var(--space-4);">
+          <li>Spine-Farbe spiegelt aktuell den Brand-Akzent (<code>--color-primary-soft</code> → hover <code>--color-primary</code>). In Phase 2 kann sie operativen Status tragen (z.&nbsp;B. <code>--color-wx-vmc / -mvfr / -ifr</code>).</li>
+          <li><code>.ad-name</code> ellipsiert; <code>.ad-meta</code>, Signals und Stern haben <code>flex-shrink: 0</code> — die Identitäts-Spalte gibt zuerst nach.</li>
+          <li>Unter 540&nbsp;px wird <code>.ad-signals</code> ausgeblendet (Mobile-Drawer-Use-Case).</li>
+          <li>Fokus-Outline 2&nbsp;px primary mit 2&nbsp;px Offset — klar erkennbar in beiden Themes ohne den Spine zu verdecken.</li>
+          <li>Keine Translate-Animation: Listen-Items, die im Hover springen, sind in einem Stack mit 6 Einträgen ermüdend. Nur Background + Spine wechseln.</li>
         </ul>
       </section>
 

--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -332,4 +332,8 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 
 > ja, mach Issue und Fix
 
+### 2026-05-17 — Warum keine Favoriten auf der Übersicht? (`develop`)
+
+> Warum sehe ich hier keine Favoriten? [Screenshot Dashboard mit "Noch keine Favoriten — öffne einen Flugplatz, um ihn zu merken."]
+
 

--- a/services/frontend/src/api/aerodromes.test.ts
+++ b/services/frontend/src/api/aerodromes.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Aerodrome } from "./aerodromes";
+
+const listAerodromesMock = vi.fn();
+
+vi.mock("./client", async () => {
+  const actual = await vi.importActual<typeof import("./client")>("./client");
+  return {
+    ...actual,
+    apiListJson: (...args: unknown[]) => listAerodromesMock(...args),
+  };
+});
+
+const { fetchAerodromeByIcao } = await import("./aerodromes");
+
+function aerodrome(icao: string, overrides: Partial<Aerodrome> = {}): Aerodrome {
+  return {
+    icao,
+    iata: null,
+    name: icao,
+    name_de: null,
+    city: null,
+    city_de: null,
+    region: null,
+    region_de: null,
+    country: "DE",
+    type: "international",
+    latitude: null,
+    longitude: null,
+    elevation_ft: null,
+    source_airac_cycle: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listAerodromesMock.mockReset();
+});
+
+afterEach(() => {
+  listAerodromesMock.mockReset();
+});
+
+describe("fetchAerodromeByIcao", () => {
+  it("normalizes input to uppercase before querying", async () => {
+    listAerodromesMock.mockResolvedValue({ items: [aerodrome("EDDF")], total: 1 });
+
+    await fetchAerodromeByIcao("eddf");
+
+    expect(listAerodromesMock).toHaveBeenCalledWith(
+      "/aerodromes",
+      expect.objectContaining({ q: "EDDF", limit: 5 }),
+    );
+  });
+
+  it("returns the exact ICAO match when the endpoint returns prefix hits", async () => {
+    listAerodromesMock.mockResolvedValue({
+      items: [aerodrome("EDDF"), aerodrome("EDDFM")],
+      total: 2,
+    });
+
+    const result = await fetchAerodromeByIcao("EDDF");
+
+    expect(result?.icao).toBe("EDDF");
+  });
+
+  it("returns null when no exact match is in the prefix response", async () => {
+    listAerodromesMock.mockResolvedValue({
+      items: [aerodrome("EDDFA"), aerodrome("EDDFB")],
+      total: 2,
+    });
+
+    const result = await fetchAerodromeByIcao("EDDF");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error instead of throwing", async () => {
+    listAerodromesMock.mockRejectedValue(new Error("network"));
+
+    const result = await fetchAerodromeByIcao("EDDF");
+
+    expect(result).toBeNull();
+  });
+});

--- a/services/frontend/src/api/aerodromes.ts
+++ b/services/frontend/src/api/aerodromes.ts
@@ -147,3 +147,19 @@ export function setChartRotation(
 ): Promise<{ id: number; rotation_degrees: RotationDegrees }> {
   return apiPatchJson(`/aerodromes/${icao}/charts/${chartId}/rotation`, { degrees });
 }
+
+/**
+ * Fetch a single aerodrome by ICAO via the prefix-search list endpoint and
+ * return the exact ICAO match. Used by every view that hydrates favorite
+ * ICAOs into full Aerodrome objects (favorites tab in Search, dashboard
+ * widget). Returns null on network/HTTP error or when no exact match exists.
+ */
+export async function fetchAerodromeByIcao(icao: string): Promise<Aerodrome | null> {
+  const code = icao.trim().toUpperCase();
+  try {
+    const res = await listAerodromes({ q: code, limit: 5 });
+    return res.items.find((a) => a.icao.toUpperCase() === code) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/services/frontend/src/components/AerodromeCardCompact.tsx
+++ b/services/frontend/src/components/AerodromeCardCompact.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router-dom";
+
+import type { Aerodrome } from "@/api/aerodromes";
+import { FavoriteToggle } from "@/components/FavoriteToggle";
+import { useI18n } from "@/i18n";
+
+interface Props {
+  aerodrome: Aerodrome;
+  /** Optional TWR frequency (MHz). Rendered as a mono stat chip when set. */
+  twrFrequency?: string | number | null;
+  /** Optional runway count. Rendered as a mono stat chip when > 0. */
+  runwayCount?: number;
+}
+
+/**
+ * Compact list-item variant of `AerodromeCard` — design kit §28.
+ *
+ * Used in the dashboard favorites widget where multiple aerodromes stack
+ * vertically inside a ~700 px panel. Click anywhere navigates to the detail
+ * page; the embedded star toggle stops propagation.
+ */
+export function AerodromeCardCompact({ aerodrome, twrFrequency, runwayCount }: Props) {
+  const { locale } = useI18n();
+  const name = locale === "de" && aerodrome.name_de ? aerodrome.name_de : aerodrome.name;
+  const region =
+    locale === "de" && aerodrome.region_de ? aerodrome.region_de : aerodrome.region;
+  const hasStats = (twrFrequency != null && twrFrequency !== "") || (runwayCount ?? 0) > 0;
+
+  return (
+    <Link
+      to={`/aerodromes/${aerodrome.icao}`}
+      className="aerodrome-card aerodrome-card--compact"
+    >
+      <div className="ad-icao">{aerodrome.icao}</div>
+      <div className="ad-body">
+        <span className="ad-name">{name}</span>
+        {region && <span className="ad-meta">{region}</span>}
+      </div>
+      {hasStats && (
+        <div className="ad-signals">
+          {twrFrequency != null && twrFrequency !== "" && (
+            <span className="ad-stat" title="Tower frequency">
+              <i className="fa-solid fa-tower-broadcast" aria-hidden="true" /> {twrFrequency}
+            </span>
+          )}
+          {(runwayCount ?? 0) > 0 && (
+            <span className="ad-stat" title="Runways">
+              <i className="fa-solid fa-road" aria-hidden="true" /> {runwayCount}
+            </span>
+          )}
+        </div>
+      )}
+      <FavoriteToggle icao={aerodrome.icao} size="sm" />
+    </Link>
+  );
+}

--- a/services/frontend/src/i18n/de.ts
+++ b/services/frontend/src/i18n/de.ts
@@ -210,6 +210,9 @@ export const de: Record<TranslationKey, string> = {
   "action.retry": "Erneut versuchen",
   "action.backToSearch": "Zurück zur Suche",
 
+  // Dashboard favorites widget (#61)
+  "dashboard.favorites.more": "+{n} weitere",
+
   // Favorites (#55)
   "favorites.toggle.add": "Zu Favoriten hinzufügen",
   "favorites.toggle.remove": "Aus Favoriten entfernen",

--- a/services/frontend/src/i18n/en.ts
+++ b/services/frontend/src/i18n/en.ts
@@ -219,6 +219,9 @@ export const en = {
   "action.retry": "Retry",
   "action.backToSearch": "Back to search",
 
+  // Dashboard favorites widget (#61)
+  "dashboard.favorites.more": "+{n} more",
+
   // Favorites (#55)
   "favorites.toggle.add": "Add to favorites",
   "favorites.toggle.remove": "Remove from favorites",

--- a/services/frontend/src/pages/Dashboard.tsx
+++ b/services/frontend/src/pages/Dashboard.tsx
@@ -1,19 +1,55 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { listAerodromes } from "@/api/aerodromes";
+import {
+  fetchAerodromeByIcao,
+  listAerodromes,
+  type Aerodrome,
+} from "@/api/aerodromes";
+import { AerodromeCardCompact } from "@/components/AerodromeCardCompact";
+import { useFavorites } from "@/hooks/useFavorites";
 import { useI18n } from "@/i18n";
+
+const FAVORITES_VISIBLE = 6;
 
 export function Dashboard() {
   const { t } = useI18n();
   const [total, setTotal] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const {
+    favorites,
+    count: favoritesCount,
+    loaded: favoritesLoaded,
+  } = useFavorites();
+  const [favoriteAerodromes, setFavoriteAerodromes] = useState<Aerodrome[]>([]);
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
 
   useEffect(() => {
     listAerodromes({ limit: 1 })
       .then((res) => setTotal(res.total))
       .catch((e) => setError(e.message));
   }, []);
+
+  useEffect(() => {
+    if (!favoritesLoaded) return;
+    if (favoritesCount === 0) {
+      setFavoriteAerodromes([]);
+      setFavoritesError(null);
+      return;
+    }
+    const icaos = Array.from(favorites).sort();
+    Promise.all(icaos.map(fetchAerodromeByIcao))
+      .then((results) => {
+        setFavoriteAerodromes(results.filter((a): a is Aerodrome => a !== null));
+        setFavoritesError(null);
+      })
+      .catch((e) =>
+        setFavoritesError(e instanceof Error ? e.message : String(e)),
+      );
+  }, [favoritesLoaded, favorites, favoritesCount]);
+
+  const visibleFavorites = favoriteAerodromes.slice(0, FAVORITES_VISIBLE);
+  const hiddenFavorites = favoriteAerodromes.length - visibleFavorites.length;
 
   return (
     <>
@@ -60,14 +96,65 @@ export function Dashboard() {
         <div className="col-span-8">
           <div className="card" style={{ marginBottom: "var(--space-4)" }}>
             <div className="card-header">
-              <span className="card-title">{t("dashboard.section.favorites")}</span>
-              <Link to="/search" className="btn btn-ghost btn-sm">
-                {t("nav.search")}
+              <span className="card-title">
+                {t("dashboard.section.favorites")}
+                {favoritesCount > 0 && (
+                  <span
+                    style={{
+                      marginLeft: "var(--space-2)",
+                      padding: "1px 8px",
+                      borderRadius: 999,
+                      background: "var(--color-primary-soft)",
+                      color: "var(--color-primary)",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "11px",
+                      fontWeight: 600,
+                    }}
+                  >
+                    {favoritesCount}
+                  </span>
+                )}
+              </span>
+              <Link to="/search?tab=favorites" className="btn btn-ghost btn-sm">
+                {t("favorites.tab.favorites")}
               </Link>
             </div>
-            <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--fs-sm)", margin: 0 }}>
-              {t("dashboard.favorites.empty")}
-            </p>
+
+            {!favoritesLoaded ? (
+              <p style={{ color: "var(--color-text-muted)", fontSize: "var(--fs-sm)", margin: 0 }}>
+                {t("search.loading")}
+              </p>
+            ) : favoritesError ? (
+              <p style={{ color: "var(--color-text-muted)", fontSize: "var(--fs-sm)", margin: 0 }}>
+                {t("favorites.error", { message: favoritesError })}
+              </p>
+            ) : favoritesCount === 0 ? (
+              <p
+                style={{
+                  color: "var(--color-text-secondary)",
+                  fontSize: "var(--fs-sm)",
+                  margin: 0,
+                }}
+              >
+                {t("dashboard.favorites.empty")}
+              </p>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+                {visibleFavorites.map((ad) => (
+                  <AerodromeCardCompact key={ad.icao} aerodrome={ad} />
+                ))}
+                {hiddenFavorites > 0 && (
+                  <Link
+                    to="/search?tab=favorites"
+                    className="btn btn-ghost btn-sm"
+                    style={{ alignSelf: "flex-start", marginTop: "var(--space-2)" }}
+                  >
+                    {t("dashboard.favorites.more", { n: hiddenFavorites })}{" "}
+                    <i className="fa-solid fa-arrow-right" aria-hidden="true" />
+                  </Link>
+                )}
+              </div>
+            )}
           </div>
           <div className="card">
             <div className="card-header">

--- a/services/frontend/src/pages/Search.tsx
+++ b/services/frontend/src/pages/Search.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import {
-  listAerodromes,
+  fetchAerodromeByIcao,
   searchAerodromes,
   type Aerodrome,
   type AerodromeSearchHit,
@@ -37,17 +37,6 @@ const TYPES: (AerodromeType | "")[] = [
   "private",
   "other",
 ];
-
-/** Fetch one aerodrome via the prefix-search list endpoint, picking the exact ICAO match. */
-async function fetchAerodromeByIcao(icao: string): Promise<Aerodrome | null> {
-  const code = icao.trim().toUpperCase();
-  try {
-    const res = await listAerodromes({ q: code, limit: 5 });
-    return res.items.find((a) => a.icao.toUpperCase() === code) ?? null;
-  } catch {
-    return null;
-  }
-}
 
 export function SearchPage() {
   const { t } = useI18n();

--- a/services/frontend/src/styles/global.css
+++ b/services/frontend/src/styles/global.css
@@ -462,6 +462,118 @@ a:hover {
   font-weight: 700;
 }
 
+/* ------- Aerodrome Card — Compact (Design Kit §28) ------- */
+.aerodrome-card.aerodrome-card--compact {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4) var(--space-2) 0;
+  border-radius: var(--radius-md);
+  min-height: 56px;
+  position: relative;
+  overflow: hidden;
+  transition: background var(--duration-fast), border-color var(--duration-fast);
+}
+
+.aerodrome-card.aerodrome-card--compact:hover,
+.aerodrome-card.aerodrome-card--compact:focus-visible {
+  transform: none;
+  background: var(--color-surface-2);
+  border-color: var(--color-border-strong);
+  box-shadow: none;
+  text-decoration: none;
+}
+
+.aerodrome-card.aerodrome-card--compact:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.aerodrome-card.aerodrome-card--compact::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--color-primary-soft);
+  transition: background var(--duration-fast);
+}
+
+.aerodrome-card.aerodrome-card--compact:hover::before,
+.aerodrome-card.aerodrome-card--compact:focus-visible::before {
+  background: var(--color-primary);
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-icao {
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  font-weight: 700;
+  color: var(--color-primary);
+  letter-spacing: -0.02em;
+  padding-left: var(--space-4);
+  min-width: 76px;
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-body {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-name {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Override the full card's flex+icon .ad-meta styling — inline-only here. */
+.aerodrome-card.aerodrome-card--compact .ad-meta {
+  font-size: var(--fs-xs);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  display: inline;
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-meta::before {
+  content: "·";
+  margin-right: var(--space-2);
+  color: var(--color-border-strong);
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-signals {
+  display: inline-flex;
+  gap: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.aerodrome-card.aerodrome-card--compact .ad-stat i {
+  color: var(--color-text-muted);
+  font-size: 10px;
+}
+
+@media (max-width: 540px) {
+  .aerodrome-card.aerodrome-card--compact .ad-signals {
+    display: none;
+  }
+}
+
 /* ------- Frequency badge ------- */
 .freq-badge {
   display: inline-flex;


### PR DESCRIPTION
Closes #61.

## Summary
The Dashboard's „Favoriten"-Widget used to show a static placeholder regardless of how many favorites the user had. Now it renders up to 6 favorites as a new compact card variant (design kit §28), with a "+N weitere" link to `/search?tab=favorites` for the overflow.

## Highlights
- **New design kit section §28** — Aerodrome Card (Compact). Single-row "flight strip" aesthetic: 3px primary spine on the left edge, mono ICAO anchor (deliberately smaller than the full card's `fs-2xl`), inline name + region, two terse mono stat chips (TWR frequency + runway count, when known), star toggle on the right. Hover saturates the spine to `--color-primary`; no translate (jumping list rows are nauseating stacked).
- **New `AerodromeCardCompact` React component** rendering the §28 markup.
- **`fetchAerodromeByIcao` extracted** from `Search.tsx` into `api/aerodromes.ts` so the Dashboard widget and the Search favorites tab both reuse it. Covered by 4 vitest cases (uppercase normalization, exact-match preference, no-match → null, error → null).
- **`useFavorites` integration**: alphabetical-by-ICAO sort (matches Search favorites tab), parallel hydration, optimistic toggle/remove via existing star toggle in each compact card.
- **Empty state preserved**: when `count === 0` the original placeholder copy + link to search stays.
- **i18n**: new key `dashboard.favorites.more` (DE: „+{n} weitere", EN: „+{n} more").

## Services affected
- `services/frontend/src/pages/Dashboard.tsx` — widget wired to store
- `services/frontend/src/components/AerodromeCardCompact.tsx` — new
- `services/frontend/src/api/aerodromes.ts` — helper extracted + exported
- `services/frontend/src/api/aerodromes.test.ts` — new helper tests
- `services/frontend/src/pages/Search.tsx` — imports the shared helper instead of its private copy
- `services/frontend/src/i18n/{en,de}.ts` — new key
- `services/frontend/src/styles/global.css` — §28 CSS port
- `docs/Design-Kits/aerofly-design-kit.html` — new §28 + TOC

No backend changes.

## Test plan
- [x] vitest: 18/18 passed (4 new helper + 14 existing)
- [x] `npx tsc --noEmit` clean
- [x] Smoke: `GET http://localhost:13000/` → 200
- [ ] Manual (reviewer): reload dashboard with 0/1/3/7 favorites; verify counter, spine accent on hover, "+N weitere" overflow link, star-removal updates the list immediately, navigating away into a detail page and back still works