### PR TITLE
[#69] feat: per-aerodrome /sync endpoint + UI button (Part B / Phase 1 complete)

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -364,4 +364,12 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 
 > c
 
+### 2026-05-18 — Bestätigung: /airac/current funktioniert (`develop`)
+
+> [Screenshot von localhost:18003/airac/current zeigt {"edition":"2026MAY05"}]
+
+### 2026-05-18 — Part B starten (Frontend komplett nutzbar) (`develop`)
+
+> ja, mach weiter mit Part B - ich brauche das update aber über das frontend komplett nutzbar. das ist schon klar, oder?
+
 

--- a/services/data-ingestion/app/api/sync.py
+++ b/services/data-ingestion/app/api/sync.py
@@ -1,0 +1,111 @@
+"""Async per-aerodrome **sync** trigger (scrape → import → extract).
+
+A sync job goes one further than the legacy `/extract` endpoint: it
+first refreshes the scraped chart material from DFS via the sidecar
+scraper service, then re-imports the manifest into the DB, then runs
+the existing 2-of-2 extraction. The frontend polls the same
+ExtractionJob row that was used before; the `current_step` field
+carries the phase string for live UI feedback.
+
+Endpoint URL is mounted under `/aerodromes/{icao}/sync` to mirror the
+existing `/aerodromes/{icao}/extract` shape — the gateway forwards
+both identically.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.api.extraction import _get_providers, _get_session_factory, _job_to_dict, get_db
+from app.db.models import Aerodrome, ExtractionJob
+from app.services.sync_pipeline import SyncPipeline
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/aerodromes", tags=["sync"])
+
+
+@router.post(
+    "/{icao}/sync",
+    status_code=202,
+    summary="Refresh charts from DFS and re-extract structured fields",
+    description=(
+        "Three-phase pipeline for one aerodrome: (1) the scraper sidecar "
+        "downloads fresh PNGs from DFS BasicVFR, (2) the manifest is imported "
+        "into the DB, (3) the existing 2-of-2 LLM consensus extraction runs "
+        "over the (possibly new) charts. Returns the ExtractionJob immediately; "
+        "the client polls `/extraction/aerodromes/{icao}/latest` for status."
+    ),
+)
+def start_sync(
+    icao: Annotated[str, Path(min_length=4, max_length=4)],
+    background: BackgroundTasks,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    icao = icao.upper()
+
+    aerodrome = db.get(Aerodrome, icao)
+    if aerodrome is None:
+        raise HTTPException(status_code=404, detail=f"Aerodrome {icao} not found")
+
+    # Active-job dedup — same logic as POST /extract, but the staleness
+    # window is wider because the scrape phase can legitimately take
+    # several minutes (especially the first run after AIRAC change which
+    # rebuilds the airport index).
+    STALE_AFTER = timedelta(minutes=20)
+    now = datetime.now(timezone.utc)
+
+    active = db.execute(
+        select(ExtractionJob)
+        .where(
+            ExtractionJob.aerodrome_icao == icao,
+            ExtractionJob.status.in_(("queued", "running")),
+        )
+        .order_by(ExtractionJob.created_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+    if active is not None:
+        last_activity = active.started_at or active.created_at
+        if last_activity.tzinfo is None:
+            last_activity = last_activity.replace(tzinfo=timezone.utc)
+        if now - last_activity > STALE_AFTER:
+            log.warning(
+                "Promoting stale sync job %s on %s to failed (last activity %s ago)",
+                active.id, icao, now - last_activity,
+            )
+            active.status = "failed"
+            active.error = (
+                f"Stuck for {(now - last_activity).total_seconds():.0f}s without "
+                "progress — treated as abandoned, please retry."
+            )
+            active.completed_at = now
+            db.commit()
+        else:
+            return _job_to_dict(active)
+
+    job = ExtractionJob(
+        aerodrome_icao=icao,
+        status="queued",
+        progress_pct=0,
+        current_step="In Warteschlange",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    pipeline = SyncPipeline(
+        session_factory=_get_session_factory(),
+        providers=_get_providers(),
+        scraper_url=settings.scraper_url,
+    )
+    background.add_task(pipeline.run, job.id, icao)
+
+    return _job_to_dict(job)

--- a/services/data-ingestion/app/core/config.py
+++ b/services/data-ingestion/app/core/config.py
@@ -16,6 +16,11 @@ class Settings(BaseSettings):
 
     dfs_base_url: str = "https://aip.dfs.de"
 
+    # The sidecar scraper container. Overridable via SCRAPER_URL env (set in
+    # docker-compose.yml). Used by the sync pipeline to drive Playwright-
+    # driven DFS scrapes.
+    scraper_url: str = "http://scraper:8003"
+
     @property
     def database_url(self) -> str:
         return (

--- a/services/data-ingestion/app/main.py
+++ b/services/data-ingestion/app/main.py
@@ -11,6 +11,7 @@ from app.api.aerodromes import router as aerodromes_router
 from app.api.charts import router as charts_router
 from app.api.extraction import router as extraction_router
 from app.api.extraction import trigger_router as extraction_trigger_router
+from app.api.sync import router as sync_router
 from app.api.usage import router as usage_router
 from app.core.config import settings
 from app.db import get_session_factory
@@ -75,6 +76,7 @@ app.include_router(charts_router)
 app.include_router(usage_router)
 app.include_router(extraction_router)
 app.include_router(extraction_trigger_router)
+app.include_router(sync_router)
 
 
 @app.get("/health", tags=["health"])

--- a/services/data-ingestion/app/services/manifest_import.py
+++ b/services/data-ingestion/app/services/manifest_import.py
@@ -1,0 +1,180 @@
+"""Per-aerodrome manifest import.
+
+Extracted from `scripts/import_scraped_data.py` so the sync pipeline can
+import ONE aerodrome's freshly scraped manifest at a time. The bulk
+script still works unchanged for host-side ops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Aerodrome, AiracCycle, Chart
+from shared.schemas.enums import AerodromeType, ChartType
+
+log = logging.getLogger(__name__)
+
+DATA_ROOT = Path("/app/data/aerodromes")
+_DFS_BASE = "https://aip.dfs.de/BasicVFR"
+
+_MONTH_MAP = {
+    "JAN": "01", "FEB": "02", "MAR": "03", "APR": "04",
+    "MAY": "05", "JUN": "06", "JUL": "07", "AUG": "08",
+    "SEP": "09", "OCT": "10", "NOV": "11", "DEC": "12",
+}
+
+
+def edition_to_airac(edition: str) -> str:
+    """Convert a scraper edition slug like '2026MAY05' → AIRAC cycle '2026-05'."""
+    match = re.match(r"(\d{4})([A-Z]{3})(\d{2})", edition)
+    if not match:
+        return "unknown"
+    year, month_abbr, _ = match.groups()
+    return f"{year}-{_MONTH_MAP.get(month_abbr, '01')}"
+
+
+def classify_chart(dfs_name: str) -> ChartType:
+    name = dfs_name.lower()
+    if re.search(r"\bad[\s_]*2[-_]", name):
+        return ChartType.AD_INFO
+    if "terminal" in name:
+        return ChartType.AD_CHART
+    if "parking" in name or "apron" in name:
+        return ChartType.PARKING
+    if "taxi" in name:
+        return ChartType.TAXI
+    if "sid" in name:
+        return ChartType.SID
+    if "star" in name:
+        return ChartType.STAR
+    if "iac" in name or "ils" in name or "approach" in name:
+        return ChartType.IAC
+    if "vac" in name or "visual" in name:
+        return ChartType.VAC
+    return ChartType.GENERAL
+
+
+def _ensure_airac_cycle(session: Session, airac: str) -> None:
+    if airac == "unknown":
+        return
+    if session.get(AiracCycle, airac) is not None:
+        return
+    year, month = airac.split("-")
+    effective_from = date(int(year), int(month), 1)
+    if int(month) < 12:
+        effective_to = date(int(year), int(month) + 1, 1)
+    else:
+        effective_to = date(int(year) + 1, 1, 1)
+    session.add(
+        AiracCycle(
+            ident=airac,
+            effective_from=effective_from,
+            effective_to=effective_to,
+            is_current=True,
+        )
+    )
+
+
+def import_one_manifest(
+    icao: str,
+    session: Session,
+    *,
+    data_root: Path = DATA_ROOT,
+) -> dict[str, Any]:
+    """Import a single aerodrome's `manifest.json` into the DB.
+
+    Returns a small summary dict (`{"aerodromes_added": int, "charts_added": int,
+    "charts_skipped": int, "edition": str, "airac": str}`). Idempotent: aerodromes
+    and charts that already exist are left alone.
+    """
+    icao = icao.strip().upper()
+    manifest_path = data_root / icao / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"No manifest for {icao} at {manifest_path}")
+
+    with manifest_path.open(encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    if manifest.get("icao", "").upper() != icao:
+        raise ValueError(
+            f"Manifest icao={manifest.get('icao')!r} does not match requested {icao!r}"
+        )
+
+    edition = manifest.get("edition", "")
+    airac = edition_to_airac(edition)
+    _ensure_airac_cycle(session, airac)
+
+    summary = {
+        "aerodromes_added": 0,
+        "charts_added": 0,
+        "charts_skipped": 0,
+        "edition": edition,
+        "airac": airac,
+    }
+
+    aerodrome = session.get(Aerodrome, icao)
+    if aerodrome is None:
+        name = manifest.get("name") or icao
+        aerodrome = Aerodrome(
+            icao=icao,
+            name=name,
+            name_de=name,
+            country="DE",
+            type=AerodromeType.OTHER,
+            source_airac_cycle=airac if airac != "unknown" else None,
+        )
+        session.add(aerodrome)
+        session.flush()
+        summary["aerodromes_added"] = 1
+
+    for doc in manifest.get("documents", []):
+        if doc.get("error"):
+            continue
+
+        permalink = doc.get("permalink") or ""
+        source_url = (
+            f"{_DFS_BASE}/{edition}/{permalink}"
+            if edition and permalink
+            else f"local://{icao}/{doc.get('normalized_name', 'unknown')}"
+        )
+
+        existing = (
+            session.query(Chart).filter(Chart.source_url == source_url).first()
+        )
+        if existing is not None:
+            summary["charts_skipped"] += 1
+            continue
+
+        dfs_name = doc.get("dfs_name") or doc.get("normalized_name") or "Chart"
+        local_preview = doc.get("preview_file")
+        local_path = (
+            f"/app/data/aerodromes/{icao}/{local_preview}" if local_preview else None
+        )
+
+        session.add(
+            Chart(
+                aerodrome_icao=icao,
+                chart_type=classify_chart(dfs_name),
+                title=dfs_name,
+                title_de=dfs_name,
+                source_url=source_url,
+                local_path=local_path,
+                language="de",
+                source_airac_cycle=airac if airac != "unknown" else None,
+            )
+        )
+        summary["charts_added"] += 1
+
+    # Refresh the aerodrome's source_airac_cycle so the detail header
+    # reflects the freshly-scraped edition even when no new charts landed.
+    if airac != "unknown" and aerodrome.source_airac_cycle != airac:
+        aerodrome.source_airac_cycle = airac
+
+    return summary

--- a/services/data-ingestion/app/services/sync_pipeline.py
+++ b/services/data-ingestion/app/services/sync_pipeline.py
@@ -1,0 +1,177 @@
+"""End-to-end aerodrome sync orchestration.
+
+A single sync job moves through three phases for one ICAO:
+
+1. **Scrape** — HTTP call to the sidecar `scraper` service, which uses
+   Playwright + Chromium to refresh the chart PNGs + manifest on the
+   shared `data/aerodromes/<ICAO>/` volume.
+2. **Import** — read the refreshed manifest and upsert aerodrome + chart
+   rows into the `ingest` schema (idempotent).
+3. **Extract** — re-run the existing 2-of-2 LLM consensus pipeline over
+   the (possibly new) charts to refresh structured fields.
+
+Implementation re-uses the existing `ExtractionJob` row: each phase
+updates `current_step` so the UI shows where we are without needing a
+new DB column.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import UUID
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.models import ExtractionJob
+from app.parser.providers.base import ExtractionProvider
+from app.services.extraction_runner import ExtractionRunner
+from app.services.manifest_import import import_one_manifest
+
+log = logging.getLogger(__name__)
+
+_SCRAPE_POLL_INTERVAL_SECONDS = 5
+_SCRAPE_MAX_WAIT_SECONDS = 600  # 10 minutes — generous for the first-time index rebuild
+_HTTP_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
+
+
+class SyncPipeline:
+    """Runs the full scrape → import → extract sequence for one aerodrome."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Callable[[], Session],
+        providers: list[ExtractionProvider],
+        scraper_url: str | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._providers = providers
+        self._scraper_url = (scraper_url or settings.scraper_url).rstrip("/")
+
+    # ------------------------------------------------------------------ #
+    # Public entry — async, called from FastAPI BackgroundTasks
+    # ------------------------------------------------------------------ #
+
+    async def run(self, job_id: UUID, icao: str) -> None:
+        icao = icao.upper()
+        try:
+            self._update_job(job_id, status="running", step="Karten werden geladen…", progress=5)
+            scrape_summary = await self._scrape(icao)
+            self._update_job(job_id, step="Karten werden importiert…", progress=35)
+            import_summary = self._import(icao)
+            log.info("sync %s scrape=%s import=%s", icao, scrape_summary, import_summary)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("sync pipeline pre-extract failed for %s", icao)
+            self._fail_job(job_id, exc)
+            return
+
+        # Hand off to the existing extraction runner (sync code). Run it in
+        # a worker thread so we don't block the asyncio loop. The runner
+        # itself updates current_step / progress in the same row.
+        self._update_job(job_id, step="Felder werden extrahiert…", progress=55)
+        runner = ExtractionRunner(
+            session_factory=self._session_factory,
+            providers=self._providers,
+        )
+        try:
+            await asyncio.to_thread(runner.run, job_id, icao)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("extraction phase failed for %s", icao)
+            self._fail_job(job_id, exc)
+
+    # ------------------------------------------------------------------ #
+    # Phases
+    # ------------------------------------------------------------------ #
+
+    async def _scrape(self, icao: str) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, base_url=self._scraper_url) as client:
+            response = await client.post(f"/scrape/{icao}")
+            response.raise_for_status()
+            kickoff = response.json()
+            scrape_job_id = kickoff["id"]
+
+            deadline = asyncio.get_event_loop().time() + _SCRAPE_MAX_WAIT_SECONDS
+            while True:
+                if asyncio.get_event_loop().time() > deadline:
+                    raise TimeoutError(
+                        f"scrape job {scrape_job_id} did not finish within "
+                        f"{_SCRAPE_MAX_WAIT_SECONDS}s"
+                    )
+                await asyncio.sleep(_SCRAPE_POLL_INTERVAL_SECONDS)
+                status_resp = await client.get(f"/scrape/jobs/{scrape_job_id}")
+                status_resp.raise_for_status()
+                state = status_resp.json()
+                if state["status"] == "completed":
+                    return state.get("result") or {}
+                if state["status"] == "failed":
+                    raise RuntimeError(
+                        f"scraper service reported failure: {state.get('error') or 'unknown'}"
+                    )
+
+    def _import(self, icao: str) -> dict[str, Any]:
+        session = self._session_factory()
+        try:
+            summary = import_one_manifest(icao, session)
+            session.commit()
+            return summary
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    # ------------------------------------------------------------------ #
+    # Job-row helpers
+    # ------------------------------------------------------------------ #
+
+    def _update_job(
+        self,
+        job_id: UUID,
+        *,
+        status: str | None = None,
+        step: str | None = None,
+        progress: int | None = None,
+    ) -> None:
+        session = self._session_factory()
+        try:
+            job = session.get(ExtractionJob, job_id)
+            if job is None:
+                return
+            if status is not None:
+                job.status = status
+                if status == "running" and job.started_at is None:
+                    job.started_at = datetime.now(timezone.utc)
+            if step is not None:
+                job.current_step = step
+            if progress is not None:
+                job.progress_pct = progress
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def _fail_job(self, job_id: UUID, exc: Exception) -> None:
+        session = self._session_factory()
+        try:
+            job = session.get(ExtractionJob, job_id)
+            if job is None:
+                return
+            job.status = "failed"
+            job.completed_at = datetime.now(timezone.utc)
+            job.error = f"{type(exc).__name__}: {exc}"
+            job.current_step = "Fehlgeschlagen"
+            session.commit()
+            log.error("job %s marked failed: %s\n%s", job_id, exc, traceback.format_exc())
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()

--- a/services/frontend/src/api/extraction.ts
+++ b/services/frontend/src/api/extraction.ts
@@ -20,6 +20,14 @@ export function startExtraction(icao: string): Promise<ExtractionJob> {
   return apiPostJson<ExtractionJob>(`/aerodromes/${icao}/extract`);
 }
 
+/**
+ * Full per-aerodrome sync: scrape → import → extract. Returns the same
+ * ExtractionJob shape as `startExtraction`; the UI polls it identically.
+ */
+export function startSync(icao: string): Promise<ExtractionJob> {
+  return apiPostJson<ExtractionJob>(`/aerodromes/${icao}/sync`);
+}
+
 export function getExtractionJob(jobId: string): Promise<ExtractionJob> {
   return apiGetJson<ExtractionJob>(`/extraction/jobs/${jobId}`);
 }

--- a/services/frontend/src/hooks/useExtractionJob.ts
+++ b/services/frontend/src/hooks/useExtractionJob.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getExtractionJob,
   getLatestExtraction,
-  startExtraction,
+  startSync,
   type ExtractionJob,
 } from "@/api/extraction";
 
@@ -93,7 +93,12 @@ export function useExtractionJob(
     setError(null);
     stopPolling();
     try {
-      const fresh = await startExtraction(icao);
+      // Full sync: scrape DFS → import manifest → extract structured fields.
+      // The legacy /extract endpoint (charts-only re-extract) is still
+      // available via startExtraction but the UI button now always goes
+      // through the full pipeline so the user gets fresh chart material
+      // automatically.
+      const fresh = await startSync(icao);
       setJob(fresh);
       timerRef.current = window.setTimeout(() => pollOnce(fresh.id), POLL_INTERVAL_MS);
     } catch (e) {

--- a/services/frontend/src/i18n/de.ts
+++ b/services/frontend/src/i18n/de.ts
@@ -224,11 +224,11 @@ export const de: Record<TranslationKey, string> = {
   "favorites.empty.cta": "Zur Flugplatzsuche",
   "favorites.error": "Favoriten konnten nicht geladen werden: {message}",
 
-  // Extraction panel (#34)
-  "extraction.trigger": "Daten aktualisieren",
-  "extraction.running": "Wird ausgeführt…",
-  "extraction.working": "Extraktion läuft…",
-  "extraction.hint": "Startet eine LLM-Extraktion (Claude + OpenAI) mit 2-von-2-Konsens. Dauert typisch 30–120 s.",
+  // Extraction / sync panel (#34, #69 full sync)
+  "extraction.trigger": "Daten von DFS aktualisieren",
+  "extraction.running": "Wird aktualisiert…",
+  "extraction.working": "Wird ausgeführt…",
+  "extraction.hint": "Lädt frische Karten von DFS und führt anschließend die LLM-Extraktion (Claude + OpenAI, 2-von-2-Konsens) erneut aus. Typisch 2–5 Minuten.",
   "extraction.completed": "{fields} Felder geschrieben · {at}",
   "extraction.failed": "Fehlgeschlagen: {error}",
 };

--- a/services/frontend/src/i18n/en.ts
+++ b/services/frontend/src/i18n/en.ts
@@ -233,11 +233,11 @@ export const en = {
   "favorites.empty.cta": "Browse aerodromes",
   "favorites.error": "Could not load favorites: {message}",
 
-  // Extraction panel (#34)
-  "extraction.trigger": "Refresh data",
-  "extraction.running": "Running…",
-  "extraction.working": "Extracting…",
-  "extraction.hint": "Runs a 2-of-2 LLM consensus extraction (Claude + OpenAI). Typically 30–120 s.",
+  // Extraction / sync panel (#34, #69 full sync)
+  "extraction.trigger": "Refresh from DFS",
+  "extraction.running": "Refreshing…",
+  "extraction.working": "Working…",
+  "extraction.hint": "Downloads fresh charts from DFS, then re-runs the 2-of-2 LLM consensus extraction (Claude + OpenAI). Typically 2–5 minutes.",
   "extraction.completed": "{fields} fields written · {at}",
   "extraction.failed": "Failed: {error}",
 } as const;

--- a/services/gateway/app/api/aerodromes.py
+++ b/services/gateway/app/api/aerodromes.py
@@ -71,13 +71,32 @@ async def get_aerodrome(icao: str, request: Request):
 @router.post(
     "/{icao}/extract",
     status_code=202,
-    summary="Trigger async per-aerodrome LLM extraction",
+    summary="Trigger async per-aerodrome LLM extraction (legacy — re-extracts existing charts only)",
 )
 async def trigger_extraction(icao: str, request: Request):
     async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
         try:
             upstream = await client.post(
                 f"{settings.data_ingestion_url}/aerodromes/{icao}/extract"
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Upstream unreachable: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
+    return upstream.json()
+
+
+@router.post(
+    "/{icao}/sync",
+    status_code=202,
+    summary="Refresh DFS charts then re-extract structured fields (full sync)",
+)
+async def trigger_sync(icao: str, request: Request):
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        try:
+            upstream = await client.post(
+                f"{settings.data_ingestion_url}/aerodromes/{icao}/sync"
             )
         except httpx.HTTPError as exc:
             raise HTTPException(status_code=502, detail=f"Upstream unreachable: {exc}") from exc


### PR DESCRIPTION
Part B of Phase 1 of #69. Builds on PR #70 (scraper sidecar). The detail-view button now triggers the full pipeline through the gateway, fully usable from the frontend.

## Pipeline flow

```
[Browser]                       [Gateway]                  [data-ingestion]                       [scraper]
   |                                |                              |                                  |
   | POST /api/.../EDQM/sync ─────► |                              |                                  |
   |                                | POST /aerodromes/EDQM/sync ──►                                  |
   |                                |              ┌────────────── creates ExtractionJob              |
   |                                |              │               BackgroundTasks → SyncPipeline.run |
   |                                |              │   phase 1: "Karten werden geladen…"              |
   |                                |              │               POST /scrape/EDQM ──────────────► |
   |                                |              │               poll /scrape/jobs/<id>            |
   |                                |              │                     scrape (~100s)              |
   |                                |              │   phase 2: "Karten werden importiert…"          |
   |                                |              │               import_one_manifest(EDQM)         |
   |                                |              │   phase 3: "Felder werden extrahiert…"          |
   |                                |              │               ExtractionRunner.run()            |
   |                                |              │                geo / runways / frequencies / …  |
   |                                |              │   "Fertig"                                      |
   | GET .../extraction/latest ────►|                              |                                  |
   |                                | (polled every 2 s, same job-id, same shape as legacy /extract) |
```

## Backend changes
- `services/data-ingestion/app/services/manifest_import.py` *(new)* — extracted from `scripts/import_scraped_data.py` so the pipeline can import ONE freshly scraped manifest. Idempotent: aerodromes and charts with matching `source_url` are left alone; AIRAC cycle row is added if missing.
- `services/data-ingestion/app/services/sync_pipeline.py` *(new)* — async orchestrator. Updates the existing `ExtractionJob` row with phase strings (no DB column added) so the UI gets live status with no extra polling. Hands off to existing `ExtractionRunner` for phase 3 (running it in a worker thread so the asyncio loop stays free).
- `services/data-ingestion/app/api/sync.py` *(new)* — `POST /aerodromes/{icao}/sync`. Same active-job dedup + stale-sweep behaviour as legacy `/extract`, but with a 20-minute staleness window because the scrape phase can take several minutes (especially the first run after an AIRAC change, which rebuilds the airport index).
- `services/data-ingestion/app/core/config.py` — `scraper_url` setting (default `http://scraper:8003`, overridable via `SCRAPER_URL` env var — already wired in `docker-compose.yml`).
- `services/gateway/app/api/aerodromes.py` — matching `POST /api/aerodromes/{icao}/sync` proxy. Legacy `/extract` route kept (charts-only re-extract) for completeness.

## Frontend changes
- `services/frontend/src/api/extraction.ts` — new `startSync()`.
- `services/frontend/src/hooks/useExtractionJob.ts` — now triggers `/sync`. Polling + UI rendering stays untouched because the `ExtractionJob` shape is identical.
- `services/frontend/src/i18n/{en,de}.ts` — copy refreshed to reflect that this is the full pipeline:
  - DE: "Daten von DFS aktualisieren" / "Wird aktualisiert…" / hint mentions chart refresh + 2–5 min duration.
  - EN: equivalent.

## Live verification
- `pytest tests/test_extraction_runner_helpers.py tests/test_extraction_runner_aggregators.py` → 103/103 PASSED (existing suite still green).
- `npx tsc --noEmit` clean, `npx vitest run` → 18/18 PASSED.
- End-to-end on EDQM through the gateway path:

  ```
  status=running progress=5%   step='Karten werden geladen…'
  status=running progress=0%   step='geo ← EDQM_Hof-Plauen_2_print.png (2/2)'
  status=running progress=19%  step='runways ← EDQM_Hof-Plauen_2_print.png (2/2)'
  status=running progress=38%  step='frequencies ← EDQM_Hof-Plauen_1_print.png (1/2)'
  status=running progress=57%  step='obstacles ← EDQM_Hof-Plauen_1_print.png (1/2)'
  status=running progress=76%  step='reporting_points ← EDQM_Hof-Plauen_1_print.png (1/2)'
  status=completed progress=100% step='Fertig'
  ```

  DB ended up with both TWR + FIS frequencies, RWY 08/26, geo + AIRAC fields refreshed to `2026-05`.

## Test plan
- [x] Backend pytest + frontend vitest green
- [x] Live end-to-end on EDQM via gateway
- [ ] Reviewer: open the detail page for any aerodrome (e.g. http://localhost:8080/aerodromes/EDQM), click "Daten von DFS aktualisieren", watch the three phases roll through the progress bar. ~2-5 minutes total.

## What's next (separate PRs)
- Phase 2 of #69: "Alle Favoriten aktualisieren" button in the dashboard widget.
- Phase 3 of #69: settings page + AIRAC overview + full-sync (all ~433 places) with cost/time confirmation modal.