### PR TITLE
[#69] feat: bulk sync for all favorites (Phase 2)

### DIFF
--- a/docs/PROMPT_LOG.md
+++ b/docs/PROMPT_LOG.md
@@ -380,4 +380,12 @@ Persistent audit trail of all user requests. Each entry documents a user prompt 
 
 > Ich habe EDDF aktualisiert und jetzt habe ich alles doppelt. Das macht so keinen Sinn. Du musst natürlich immer nur das Aktuellste beibehalten.
 
+### 2026-05-19 — Frage: Was ist Phase 2? (`develop`)
+
+> what is phase 2?
+
+### 2026-05-19 — Phase 2 starten (Alle Favoriten Sync) (`develop`)
+
+> ja, leg los
+
 

--- a/services/data-ingestion/app/api/extraction.py
+++ b/services/data-ingestion/app/api/extraction.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -109,6 +109,40 @@ def get_latest_job(
         .limit(1)
     ).scalar_one_or_none()
     return _job_to_dict(job) if job else None
+
+
+@router.get(
+    "/aerodromes/latest-bulk",
+    summary="Latest extraction job for many aerodromes (one round trip)",
+    description=(
+        "Returns the most recent ExtractionJob per ICAO for up to 50 codes "
+        "in a single request. Used by the dashboard bulk-sync indicator so "
+        "the frontend doesn't need N separate polls."
+    ),
+)
+def get_latest_jobs_bulk(
+    icaos: Annotated[str, Query(description="Comma-separated ICAOs, e.g. 'EDDF,EDDM,EDDH'")],
+    db: Annotated[Session, Depends(get_db)],
+) -> dict[str, dict | None]:
+    requested = [code.strip().upper() for code in icaos.split(",") if code.strip()]
+    if not requested:
+        return {}
+    if len(requested) > 50:
+        raise HTTPException(status_code=400, detail="At most 50 ICAOs per request")
+
+    # Latest job per icao via window-function trick. Simpler in two passes:
+    # fetch all candidates ordered by created_at desc, then take the first
+    # we see per icao.
+    rows = db.execute(
+        select(ExtractionJob)
+        .where(ExtractionJob.aerodrome_icao.in_(requested))
+        .order_by(ExtractionJob.created_at.desc())
+    ).scalars().all()
+    latest: dict[str, dict | None] = {code: None for code in requested}
+    for row in rows:
+        if latest.get(row.aerodrome_icao) is None:
+            latest[row.aerodrome_icao] = _job_to_dict(row)
+    return latest
 
 
 # ---------------------------------------------------------------------------

--- a/services/data-ingestion/app/api/sync.py
+++ b/services/data-ingestion/app/api/sync.py
@@ -17,14 +17,17 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Path
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.api.extraction import _get_providers, _get_session_factory, _job_to_dict, get_db
 from app.db.models import Aerodrome, ExtractionJob
+from app.services.bulk_sync import BulkSync
 from app.services.sync_pipeline import SyncPipeline
 
 log = logging.getLogger(__name__)
@@ -109,3 +112,114 @@ def start_sync(
     background.add_task(pipeline.run, job.id, icao)
 
     return _job_to_dict(job)
+
+
+class BulkSyncRequest(BaseModel):
+    icaos: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="ICAO codes to sync. Processed sequentially.",
+    )
+
+
+@router.post(
+    "/sync-bulk",
+    status_code=202,
+    summary="Sync many aerodromes in one request (sequential)",
+    description=(
+        "Phase 2 of #69. Creates one ExtractionJob per ICAO and processes "
+        "them sequentially via the standard SyncPipeline (DFS politeness + "
+        "LLM-rate-limit friendly). Returns the list of created jobs; the "
+        "client polls them via `GET /extraction/latest-bulk?icaos=...` or "
+        "per-icao."
+    ),
+)
+def start_bulk_sync(
+    payload: Annotated[BulkSyncRequest, Body(...)],
+    background: BackgroundTasks,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    requested = [code.strip().upper() for code in payload.icaos]
+    # Drop duplicates while preserving order — keeps the response and the
+    # job list in the order the user sees on the dashboard.
+    seen: set[str] = set()
+    icaos: list[str] = []
+    for code in requested:
+        if not code or code in seen:
+            continue
+        seen.add(code)
+        icaos.append(code)
+    if not icaos:
+        raise HTTPException(status_code=400, detail="icaos must contain at least one valid code")
+
+    # Validate every ICAO exists before kicking off — half-failed bulk
+    # runs are confusing.
+    found = {
+        row.icao
+        for row in db.execute(
+            select(Aerodrome).where(Aerodrome.icao.in_(icaos))
+        ).scalars().all()
+    }
+    missing = [code for code in icaos if code not in found]
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown ICAOs: {', '.join(missing)}",
+        )
+
+    # Promote stale active jobs and reuse fresh ones (mirrors single-sync
+    # dedup), then create a job row for every ICAO that needs one.
+    STALE_AFTER = timedelta(minutes=20)
+    now = datetime.now(timezone.utc)
+    jobs_to_run: list[tuple[UUID, str]] = []
+    out_jobs: list[dict] = []
+
+    for icao in icaos:
+        active = db.execute(
+            select(ExtractionJob)
+            .where(
+                ExtractionJob.aerodrome_icao == icao,
+                ExtractionJob.status.in_(("queued", "running")),
+            )
+            .order_by(ExtractionJob.created_at.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if active is not None:
+            last = active.started_at or active.created_at
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
+            if now - last > STALE_AFTER:
+                active.status = "failed"
+                active.error = (
+                    f"Stuck for {(now - last).total_seconds():.0f}s without "
+                    "progress — treated as abandoned, please retry."
+                )
+                active.completed_at = now
+            else:
+                out_jobs.append(_job_to_dict(active))
+                continue
+
+        new_job = ExtractionJob(
+            aerodrome_icao=icao,
+            status="queued",
+            progress_pct=0,
+            current_step="In Warteschlange (Sammel-Sync)",
+        )
+        db.add(new_job)
+        db.flush()
+        jobs_to_run.append((new_job.id, icao))
+        out_jobs.append(_job_to_dict(new_job))
+
+    db.commit()
+
+    if jobs_to_run:
+        bulk = BulkSync(
+            session_factory=_get_session_factory(),
+            providers=_get_providers(),
+            scraper_url=settings.scraper_url,
+        )
+        background.add_task(bulk.run, jobs_to_run)
+
+    return {"jobs": out_jobs, "queued": len(jobs_to_run), "total": len(out_jobs)}

--- a/services/data-ingestion/app/services/bulk_sync.py
+++ b/services/data-ingestion/app/services/bulk_sync.py
@@ -1,0 +1,68 @@
+"""Bulk per-favorite sync orchestration.
+
+Phase 2 of #69. A single bulk request kicks off a sync for many ICAOs;
+the orchestrator processes them **sequentially** through the existing
+`SyncPipeline` so that we don't:
+
+- Hammer DFS with parallel scrape requests (politeness).
+- Run multiple Playwright contexts in the scraper container at once
+  (in-memory job_store is single-process; concurrent calls would still
+  serialise inside Chromium and just add memory pressure).
+- Exhaust LLM rate limits on the extraction phase.
+
+Each ICAO gets its own `ExtractionJob` row, so the frontend can poll
+per-aerodrome status as it already does for single syncs — the only
+new client-facing piece is a batch poller endpoint to avoid N round
+trips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.models import ExtractionJob
+from app.parser.providers.base import ExtractionProvider
+from app.services.sync_pipeline import SyncPipeline
+
+log = logging.getLogger(__name__)
+
+
+class BulkSync:
+    """Runs SyncPipeline.run for each ICAO in sequence."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Callable[[], Session],
+        providers: list[ExtractionProvider],
+        scraper_url: str | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._providers = providers
+        self._scraper_url = scraper_url or settings.scraper_url
+
+    async def run(self, jobs: list[tuple[UUID, str]]) -> None:
+        """Process (job_id, icao) pairs sequentially.
+
+        Failure of one job does not abort the rest — each is reported on
+        its own row.
+        """
+        pipeline = SyncPipeline(
+            session_factory=self._session_factory,
+            providers=self._providers,
+            scraper_url=self._scraper_url,
+        )
+        for job_id, icao in jobs:
+            try:
+                await pipeline.run(job_id, icao)
+            except asyncio.CancelledError:
+                log.warning("bulk sync cancelled mid-flight at %s", icao)
+                raise
+            except Exception:  # noqa: BLE001
+                log.exception("bulk sync: %s failed; continuing with next icao", icao)

--- a/services/data-ingestion/app/services/sync_pipeline.py
+++ b/services/data-ingestion/app/services/sync_pipeline.py
@@ -90,29 +90,58 @@ class SyncPipeline:
     # ------------------------------------------------------------------ #
 
     async def _scrape(self, icao: str) -> dict[str, Any]:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, base_url=self._scraper_url) as client:
-            response = await client.post(f"/scrape/{icao}")
-            response.raise_for_status()
-            kickoff = response.json()
-            scrape_job_id = kickoff["id"]
+        # Per-request client (no kept-alive pool). Connection re-use across a
+        # 5 s `asyncio.sleep` runs straight into uvicorn's default 5 s
+        # keep-alive timeout on the scraper side — the pooled connection
+        # gets evicted exactly when we want to use it again, and httpx
+        # raises ReadError. Opening a fresh client per request avoids
+        # the race entirely; the overhead is trivial compared to the
+        # multi-minute scrape itself.
+        async def _post_start() -> dict:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, base_url=self._scraper_url) as client:
+                response = await client.post(f"/scrape/{icao}")
+                response.raise_for_status()
+                return response.json()
 
-            deadline = asyncio.get_event_loop().time() + _SCRAPE_MAX_WAIT_SECONDS
-            while True:
-                if asyncio.get_event_loop().time() > deadline:
-                    raise TimeoutError(
-                        f"scrape job {scrape_job_id} did not finish within "
-                        f"{_SCRAPE_MAX_WAIT_SECONDS}s"
+        async def _poll(scrape_job_id: str) -> dict:
+            # Best-effort retry on transient connection errors (network blip,
+            # keep-alive race). Lets a single hiccup not abort a 2-minute scrape.
+            last_exc: Exception | None = None
+            for attempt in range(3):
+                try:
+                    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, base_url=self._scraper_url) as client:
+                        resp = await client.get(f"/scrape/jobs/{scrape_job_id}")
+                        resp.raise_for_status()
+                        return resp.json()
+                except (httpx.ReadError, httpx.RemoteProtocolError, httpx.ConnectError) as exc:
+                    last_exc = exc
+                    log.warning(
+                        "scrape poll attempt %d for %s failed (%s); retrying",
+                        attempt + 1, scrape_job_id, exc.__class__.__name__,
                     )
-                await asyncio.sleep(_SCRAPE_POLL_INTERVAL_SECONDS)
-                status_resp = await client.get(f"/scrape/jobs/{scrape_job_id}")
-                status_resp.raise_for_status()
-                state = status_resp.json()
-                if state["status"] == "completed":
-                    return state.get("result") or {}
-                if state["status"] == "failed":
-                    raise RuntimeError(
-                        f"scraper service reported failure: {state.get('error') or 'unknown'}"
-                    )
+                    await asyncio.sleep(2)
+            raise RuntimeError(
+                f"scrape poll failed 3× for {scrape_job_id}: {last_exc!r}"
+            )
+
+        kickoff = await _post_start()
+        scrape_job_id = kickoff["id"]
+
+        deadline = asyncio.get_event_loop().time() + _SCRAPE_MAX_WAIT_SECONDS
+        while True:
+            if asyncio.get_event_loop().time() > deadline:
+                raise TimeoutError(
+                    f"scrape job {scrape_job_id} did not finish within "
+                    f"{_SCRAPE_MAX_WAIT_SECONDS}s"
+                )
+            await asyncio.sleep(_SCRAPE_POLL_INTERVAL_SECONDS)
+            state = await _poll(scrape_job_id)
+            if state["status"] == "completed":
+                return state.get("result") or {}
+            if state["status"] == "failed":
+                raise RuntimeError(
+                    f"scraper service reported failure: {state.get('error') or 'unknown'}"
+                )
 
     def _import(self, icao: str) -> dict[str, Any]:
         session = self._session_factory()

--- a/services/frontend/src/api/extraction.ts
+++ b/services/frontend/src/api/extraction.ts
@@ -35,3 +35,29 @@ export function getExtractionJob(jobId: string): Promise<ExtractionJob> {
 export function getLatestExtraction(icao: string): Promise<ExtractionJob | null> {
   return apiGetJson<ExtractionJob | null>(`/aerodromes/${icao}/extraction/latest`);
 }
+
+export interface BulkSyncResponse {
+  jobs: ExtractionJob[];
+  queued: number;
+  total: number;
+}
+
+/**
+ * Kick off sequential syncs for many aerodromes in a single request.
+ * Returns the list of ExtractionJob rows (newly created or already-active
+ * ones that were re-used). Each ICAO is polled individually afterwards via
+ * `getLatestBulk`.
+ */
+export function startBulkSync(icaos: string[]): Promise<BulkSyncResponse> {
+  return apiPostJson<BulkSyncResponse>(`/aerodromes/sync-bulk`, { icaos });
+}
+
+/**
+ * One-shot poll of the latest extraction job per icao. Returns a dict keyed
+ * by ICAO; values are `null` if no job has ever run for that icao.
+ */
+export function getLatestBulk(icaos: string[]): Promise<Record<string, ExtractionJob | null>> {
+  return apiGetJson<Record<string, ExtractionJob | null>>(
+    `/aerodromes/extraction/latest-bulk?icaos=${icaos.join(",")}`,
+  );
+}

--- a/services/frontend/src/components/BulkSyncButton.tsx
+++ b/services/frontend/src/components/BulkSyncButton.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  getLatestBulk,
+  startBulkSync,
+  type ExtractionJob,
+} from "@/api/extraction";
+import { useI18n } from "@/i18n";
+
+interface Props {
+  /** ICAOs to sync — typically the user's favorites. */
+  icaos: string[];
+  /** Optional className for the wrapping container. */
+  className?: string;
+}
+
+const POLL_INTERVAL_MS = 5000;
+
+interface BulkProgress {
+  total: number;
+  completed: number;
+  failed: number;
+  runningIcao: string | null;
+}
+
+function summarise(
+  expected: string[],
+  jobs: Record<string, ExtractionJob | null>,
+): BulkProgress {
+  let completed = 0;
+  let failed = 0;
+  let runningIcao: string | null = null;
+  for (const icao of expected) {
+    const job = jobs[icao];
+    if (!job) continue;
+    if (job.status === "completed") completed += 1;
+    else if (job.status === "failed") failed += 1;
+    else if (job.status === "running" && runningIcao === null) runningIcao = icao;
+  }
+  return { total: expected.length, completed, failed, runningIcao };
+}
+
+/**
+ * Dashboard favorites widget header button. Triggers a sequential sync
+ * for every favorite the user has and shows an inline progress indicator
+ * while the bulk job runs.
+ */
+export function BulkSyncButton({ icaos, className }: Props) {
+  const { t } = useI18n();
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState<BulkProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const trackedIcaosRef = useRef<string[]>([]);
+
+  const stopPolling = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(async () => {
+    const expected = trackedIcaosRef.current;
+    if (expected.length === 0) {
+      setRunning(false);
+      return;
+    }
+    try {
+      const jobs = await getLatestBulk(expected);
+      const summary = summarise(expected, jobs);
+      setProgress(summary);
+      if (summary.completed + summary.failed >= summary.total) {
+        setRunning(false);
+        stopPolling();
+      } else {
+        timerRef.current = window.setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setRunning(false);
+      stopPolling();
+    }
+  }, [stopPolling]);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const onTrigger = useCallback(async () => {
+    if (icaos.length === 0 || running) return;
+    setError(null);
+    setRunning(true);
+    trackedIcaosRef.current = [...icaos];
+    setProgress({
+      total: icaos.length,
+      completed: 0,
+      failed: 0,
+      runningIcao: null,
+    });
+    try {
+      await startBulkSync(icaos);
+      timerRef.current = window.setTimeout(poll, POLL_INTERVAL_MS);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setRunning(false);
+    }
+  }, [icaos, running, poll]);
+
+  const disabled = icaos.length === 0 || running;
+  const label = (() => {
+    if (running && progress) {
+      if (progress.runningIcao) {
+        return t("favorites.bulkSync.running", {
+          done: progress.completed,
+          total: progress.total,
+          icao: progress.runningIcao,
+        });
+      }
+      return t("favorites.bulkSync.progress", {
+        done: progress.completed,
+        total: progress.total,
+      });
+    }
+    if (!running && progress && progress.total > 0) {
+      return t("favorites.bulkSync.done", {
+        done: progress.completed,
+        total: progress.total,
+      });
+    }
+    return t("favorites.bulkSync.trigger");
+  })();
+
+  return (
+    <div className={className} style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)" }}>
+      <button
+        type="button"
+        className="btn btn-ghost btn-sm"
+        onClick={onTrigger}
+        disabled={disabled}
+        title={icaos.length === 0 ? t("favorites.bulkSync.disabled") : undefined}
+        style={{ whiteSpace: "nowrap" }}
+      >
+        <i
+          className={
+            running ? "fa-solid fa-rotate fa-spin" : "fa-solid fa-arrows-rotate"
+          }
+          style={{ marginRight: "var(--space-2)" }}
+          aria-hidden="true"
+        />
+        {label}
+      </button>
+      {error && (
+        <span
+          style={{
+            fontSize: "var(--fs-xs)",
+            color: "var(--color-danger, #ef4444)",
+          }}
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/services/frontend/src/i18n/de.ts
+++ b/services/frontend/src/i18n/de.ts
@@ -213,6 +213,13 @@ export const de: Record<TranslationKey, string> = {
   // Dashboard favorites widget (#61)
   "dashboard.favorites.more": "+{n} weitere",
 
+  // Bulk-sync of favorites — #69 Phase 2
+  "favorites.bulkSync.trigger": "Alle aktualisieren",
+  "favorites.bulkSync.disabled": "Keine Favoriten zum Aktualisieren",
+  "favorites.bulkSync.progress": "{done}/{total} aktualisiert…",
+  "favorites.bulkSync.running": "{done}/{total} aktualisiert · {icao} läuft",
+  "favorites.bulkSync.done": "{done}/{total} aktualisiert",
+
   // Favorites (#55)
   "favorites.toggle.add": "Zu Favoriten hinzufügen",
   "favorites.toggle.remove": "Aus Favoriten entfernen",

--- a/services/frontend/src/i18n/en.ts
+++ b/services/frontend/src/i18n/en.ts
@@ -222,6 +222,13 @@ export const en = {
   // Dashboard favorites widget (#61)
   "dashboard.favorites.more": "+{n} more",
 
+  // Bulk-sync of favorites — #69 Phase 2
+  "favorites.bulkSync.trigger": "Refresh all",
+  "favorites.bulkSync.disabled": "No favorites to refresh",
+  "favorites.bulkSync.progress": "Refreshing {done}/{total}…",
+  "favorites.bulkSync.running": "Refreshing {done}/{total} · {icao} now",
+  "favorites.bulkSync.done": "Refreshed {done}/{total}",
+
   // Favorites (#55)
   "favorites.toggle.add": "Add to favorites",
   "favorites.toggle.remove": "Remove from favorites",

--- a/services/frontend/src/pages/Dashboard.tsx
+++ b/services/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   type Aerodrome,
 } from "@/api/aerodromes";
 import { AerodromeCardCompact } from "@/components/AerodromeCardCompact";
+import { BulkSyncButton } from "@/components/BulkSyncButton";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useI18n } from "@/i18n";
 
@@ -115,9 +116,12 @@ export function Dashboard() {
                   </span>
                 )}
               </span>
-              <Link to="/search?tab=favorites" className="btn btn-ghost btn-sm">
-                {t("favorites.tab.favorites")}
-              </Link>
+              <div style={{ display: "inline-flex", gap: "var(--space-2)", alignItems: "center" }}>
+                <BulkSyncButton icaos={Array.from(favorites).sort()} />
+                <Link to="/search?tab=favorites" className="btn btn-ghost btn-sm">
+                  {t("favorites.tab.favorites")}
+                </Link>
+              </div>
             </div>
 
             {!favoritesLoaded ? (

--- a/services/gateway/app/api/aerodromes.py
+++ b/services/gateway/app/api/aerodromes.py
@@ -106,6 +106,47 @@ async def trigger_sync(icao: str, request: Request):
     return upstream.json()
 
 
+@router.post(
+    "/sync-bulk",
+    status_code=202,
+    summary="Sync many aerodromes in one request (sequential)",
+)
+async def trigger_sync_bulk(request: Request):
+    body = await request.body()
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        try:
+            upstream = await client.post(
+                f"{settings.data_ingestion_url}/aerodromes/sync-bulk",
+                content=body,
+                headers={"content-type": request.headers.get("content-type", "application/json")},
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Upstream unreachable: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
+    return upstream.json()
+
+
+@router.get(
+    "/extraction/latest-bulk",
+    summary="Latest extraction job for many aerodromes (one round trip)",
+)
+async def latest_extraction_bulk(request: Request, icaos: str):
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        try:
+            upstream = await client.get(
+                f"{settings.data_ingestion_url}/extraction/aerodromes/latest-bulk",
+                params={"icaos": icaos},
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Upstream unreachable: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(status_code=upstream.status_code, detail=upstream.text)
+    return upstream.json()
+
+
 @router.get(
     "/{icao}/extraction/latest",
     summary="Latest extraction job for an aerodrome",


### PR DESCRIPTION
Phase 2 of issue #69. „Alle aktualisieren" button on the dashboard favorites widget.

## Behaviour
1. User clicks „Alle aktualisieren" next to the „Favoriten" link in the dashboard widget header.
2. Frontend sends `POST /api/aerodromes/sync-bulk {icaos: [<all favorites>]}`.
3. Backend creates one `ExtractionJob` per ICAO, kicks off a single background task that processes them sequentially via the existing `SyncPipeline` (scrape → import → extract).
4. Frontend polls `GET /api/aerodromes/extraction/latest-bulk?icaos=…` every 5 s and renders an inline status — „3/6 aktualisiert · EDQM läuft".
5. When every job is `completed` or `failed`, polling stops; the button label flips to „3/6 aktualisiert" until the user navigates away.

Sequential processing was chosen deliberately: parallel runs would
hammer DFS, multiply Chromium memory in the scraper container, and
risk LLM rate limits. A typical 6-favorite refresh takes ~15-30 minutes.

## Backend
- **`app/services/bulk_sync.py`** — `BulkSync.run([(job_id, icao), …])` loops over the pairs and awaits each `SyncPipeline.run`. A failed ICAO is logged but does not abort the queue.
- **`POST /aerodromes/sync-bulk`** — validates 1-50 ICAOs (dedup + uppercase, 404 on any unknown code), reuses or promotes-then-replaces stale active jobs, returns `{jobs, queued, total}`.
- **`GET /extraction/aerodromes/latest-bulk?icaos=`** — one round trip for N icaos, returns a dict keyed by ICAO with the latest job per code (or null).
- **Gateway proxies** at `/api/aerodromes/sync-bulk` and `/api/aerodromes/extraction/latest-bulk`.

## Sync-pipeline robustness fix (side-effect)
Discovered while testing the bulk path: the EDFE leg of a bulk run died with `httpx.ReadError` mid-scrape. Root cause was uvicorn's default 5 s `keep-alive` racing the 5 s poll interval — the pooled connection got evicted exactly when the next poll arrived.

Fix: `SyncPipeline._scrape` now opens a fresh `httpx.AsyncClient` per request (no pooled connections) and retries up to 3× on transient `ReadError`/`RemoteProtocolError`/`ConnectError` with a 2 s backoff. Re-run of EDFE after the fix completed cleanly through all 5 phases.

## Frontend
- **`BulkSyncButton`** component — trigger + status + spinner, disabled when 0 favorites. Polls via `getLatestBulk` (new API helper), summarises into `{total, completed, failed, runningIcao}`, stops automatically.
- Dashboard widget header now: `Favoriten (n)`  ·  `[Alle aktualisieren]`  ·  `[Favoriten]` link.
- New i18n keys (DE + EN): `favorites.bulkSync.{trigger, running, progress, done, disabled}`.

## Test plan
- [x] `npx tsc --noEmit` clean, `npx vitest run` → 18/18 PASSED.
- [x] Live: `POST /api/aerodromes/sync-bulk {icaos: ["EDQM","EDFE"]}` → both queued, processed serially, latest-bulk poll returned correct per-icao status. EDQM 3 charts / EDFE 9 charts — no duplicates (BUG-013 fix still holds).
- [x] Re-confirmed `httpx.ReadError` regression fix: EDFE completes through all 5 extraction phases.
- [ ] Reviewer: open the dashboard with ≥ 2 favorites, click „Alle aktualisieren", watch the status counter advance. ~5 min for 2 favs.

## What's next
Phase 3: settings page + AIRAC overview + full-sync (all 433 places) with cost/time confirmation modal.